### PR TITLE
Remove Request::originalMethod

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -39,13 +39,6 @@ class Request extends Message implements ServerRequestInterface
     protected $method;
 
     /**
-     * The original request method (ignoring override)
-     *
-     * @var string
-     */
-    protected $originalMethod;
-
-    /**
      * The request URI object
      *
      * @var \Psr\Http\Message\UriInterface
@@ -176,7 +169,7 @@ class Request extends Message implements ServerRequestInterface
         StreamInterface $body,
         array $uploadedFiles = []
     ) {
-        $this->originalMethod = $this->filterMethod($method);
+        $this->method = $this->filterMethod($method);
         $this->uri = $uri;
         $this->headers = $headers;
         $this->cookies = $cookies;
@@ -241,37 +234,7 @@ class Request extends Message implements ServerRequestInterface
      */
     public function getMethod()
     {
-        if ($this->method === null) {
-            $this->method = $this->originalMethod;
-            $customMethod = $this->getHeaderLine('X-Http-Method-Override');
-
-            if ($customMethod) {
-                $this->method = $this->filterMethod($customMethod);
-            } elseif ($this->originalMethod === 'POST') {
-                $overrideMethod = $this->filterMethod($this->getParsedBodyParam('_METHOD'));
-                if ($overrideMethod !== null) {
-                    $this->method = $overrideMethod;
-                }
-
-                if ($this->getBody()->eof()) {
-                    $this->getBody()->rewind();
-                }
-            }
-        }
-
         return $this->method;
-    }
-
-    /**
-     * Get the original HTTP method (ignore override).
-     *
-     * Note: This method is not part of the PSR-7 standard.
-     *
-     * @return string
-     */
-    public function getOriginalMethod()
-    {
-        return $this->originalMethod;
     }
 
     /**
@@ -293,7 +256,6 @@ class Request extends Message implements ServerRequestInterface
     {
         $method = $this->filterMethod($method);
         $clone = clone $this;
-        $clone->originalMethod = $method;
         $clone->method = $method;
 
         return $clone;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -61,17 +61,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('GET', $this->requestFactory()->getMethod());
     }
 
-    public function testGetOriginalMethod()
-    {
-        $this->assertEquals('GET', $this->requestFactory()->getOriginalMethod());
-    }
-
     public function testWithMethod()
     {
         $request = $this->requestFactory()->withMethod('PUT');
 
         $this->assertAttributeEquals('PUT', 'method', $request);
-        $this->assertAttributeEquals('PUT', 'originalMethod', $request);
     }
 
     /**
@@ -86,7 +80,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->requestFactory()->withMethod(null);
 
-        $this->assertAttributeEquals(null, 'originalMethod', $request);
+        $this->assertAttributeEquals(null, 'method', $request);
     }
 
     /**
@@ -126,79 +120,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Slim\Psr7\Request::createFromEnvironment
-     */
-    public function testCreateFromEnvironmentWithMultipartMethodOverride()
-    {
-        $_POST['_METHOD'] = 'PUT';
-
-        $env = Environment::mock([
-            'SCRIPT_NAME' => '/index.php',
-            'REQUEST_URI' => '/foo',
-            'REQUEST_METHOD' => 'POST',
-            'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=---foo'
-        ]);
-
-        $request = Request::createFromEnvironment($env);
-        unset($_POST);
-
-        $this->assertEquals('POST', $request->getOriginalMethod());
-        $this->assertEquals('PUT', $request->getMethod());
-    }
-
-    public function testGetMethodWithOverrideHeader()
-    {
-        $uri = new Uri('https://example.com:443/foo/bar?abc=123');
-        $headers = new Headers([
-            'HTTP_X_HTTP_METHOD_OVERRIDE' => 'PUT',
-        ]);
-        $cookies = [];
-        $serverParams = [];
-        $body = new RequestBody();
-        $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
-
-        $this->assertEquals('PUT', $request->getMethod());
-        $this->assertEquals('POST', $request->getOriginalMethod());
-    }
-
-    public function testGetMethodWithOverrideParameterFromBodyObject()
-    {
-        $uri = new Uri('https://example.com:443/foo/bar?abc=123');
-        $headers = new Headers([
-            'Content-Type' => 'application/x-www-form-urlencoded',
-        ]);
-        $cookies = [];
-        $serverParams = [];
-        $body = new RequestBody();
-        $body->write('_METHOD=PUT');
-        $body->rewind();
-        $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
-
-        $this->assertEquals('PUT', $request->getMethod());
-        $this->assertEquals('POST', $request->getOriginalMethod());
-    }
-
-    public function testGetMethodOverrideParameterFromBodyArray()
-    {
-        $uri = new Uri('https://example.com:443/foo/bar?abc=123');
-        $headers = new Headers([
-            'Content-Type' => 'application/x-www-form-urlencoded',
-        ]);
-        $cookies = [];
-        $serverParams = [];
-        $body = new RequestBody();
-        $body->write('_METHOD=PUT');
-        $body->rewind();
-        $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
-        $request->registerMediaTypeParser('application/x-www-form-urlencoded', function ($input) {
-            parse_str($input, $body);
-            return $body; // <-- Array
-        });
-
-        $this->assertEquals('PUT', $request->getMethod());
-    }
-
-    /**
      * @expectedException \InvalidArgumentException
      */
     public function testCreateRequestWithInvalidMethodString()
@@ -227,7 +148,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsGet()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'GET');
 
@@ -237,7 +158,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsPost()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'POST');
 
@@ -247,7 +168,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsPut()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'PUT');
 
@@ -257,7 +178,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsPatch()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'PATCH');
 
@@ -267,7 +188,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsDelete()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'DELETE');
 
@@ -277,7 +198,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsHead()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'HEAD');
 
@@ -287,7 +208,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testIsOptions()
     {
         $request = $this->requestFactory();
-        $prop = new ReflectionProperty($request, 'originalMethod');
+        $prop = new ReflectionProperty($request, 'method');
         $prop->setAccessible(true);
         $prop->setValue($request, 'OPTIONS');
 


### PR DESCRIPTION
Support for `X-Http-Method-Override`, and `_METHOD` are removed from `Request` as they should be implemented as middleware in Slim itself.