### PR TITLE
Ensure Request::withUri preserves host correctly

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -566,7 +566,7 @@ class Request extends Message implements ServerRequestInterface
                 $clone->headers->set('Host', $uri->getHost());
             }
         } else {
-            if ($this->uri->getHost() !== '' && (!$this->hasHeader('Host') || $this->getHeader('Host') === null)) {
+            if ($uri->getHost() !== '' && (!$this->hasHeader('Host') || $this->getHeaderLine('Host') === '')) {
                 $clone->headers->set('Host', $uri->getHost());
             }
         }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -382,6 +382,42 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($uri2, 'uri', $clone);
     }
 
+    public function testWithUriPreservesHost()
+    {
+        // When `$preserveHost` is set to `true`, this method interacts with
+        // the Host header in the following ways:
+
+        // - If the the Host header is missing or empty, and the new URI contains
+        //   a host component, this method MUST update the Host header in the returned
+        //   request.
+        $uri1 = new Uri('');
+        $uri2 = new Uri('http://example2.com/test');
+
+        // Request
+        $headers = new Headers();
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $request = new Request('GET', $uri1, $headers, $cookies, $serverParams, $body);
+
+        $clone = $request->withUri($uri2, true);
+        $this->assertSame('example2.com', $clone->getHeaderLine('Host'));
+
+        // - If the Host header is missing or empty, and the new URI does not contain a
+        //   host component, this method MUST NOT update the Host header in the returned
+        //   request.
+        $uri3 = new Uri('');
+
+        $clone = $request->withUri($uri3, true);
+        $this->assertSame('', $clone->getHeaderLine('Host'));
+
+        // - If a Host header is present and non-empty, this method MUST NOT update
+        //   the Host header in the returned request.
+        $request = $request->withHeader('Host', 'example.com');
+        $clone = $request->withUri($uri2, true);
+        $this->assertSame('example.com', $clone->getHeaderLine('Host'));
+    }
+
     public function testGetContentType()
     {
         $headers = new Headers([


### PR DESCRIPTION
Add test and fix code for case when `withUrl`’s `$preserveHost` is set to true.

Ports https://github.com/slimphp/Slim/pull/2126 to this codebase.