### PR TITLE
Test with PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 matrix:


### PR DESCRIPTION
Travis nightly has recently been pumped to PHP 7.4. This PR adds PHP 7.3 testing back. 