### PR TITLE
Add createFromGlobals() to ServerRequestFactory

### DIFF
--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -83,7 +83,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      *
      * Note: This method is not part of PSR-17
      */
-    public static function createFromGlobals() : Request
+    public static function createFromGlobals(): Request
     {
         $server = $_SERVER;
 
@@ -96,8 +96,8 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
 
         $request = new Request($method, $uri, $headers, $cookies, $server, $body, $uploadedFiles);
 
-        if ($method === 'POST' &&
-             \in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data'])
+        if ($method === 'POST'
+            && \in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data'])
         ) {
             // parsed body must be $_POST
             $request = $request->withParsedBody($_POST);

--- a/tests/Factory/ServerRequestFactoryTest.php
+++ b/tests/Factory/ServerRequestFactoryTest.php
@@ -12,6 +12,7 @@ use Interop\Http\Factory\ServerRequestFactoryTestCase;
 use Slim\Psr7\Environment;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use Slim\Psr7\Factory\UriFactory;
+use Slim\Psr7\UploadedFile;
 
 class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
 {
@@ -42,5 +43,87 @@ class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
         $request = $this->createServerRequestFactory()->createServerRequest('GET', '', $env);
 
         $this->assertEquals('1.0', $request->getProtocolVersion());
+    }
+
+    public function testCreateFromGlobals()
+    {
+        $_SERVER = Environment::mock([
+            'HTTP_ACCEPT'          => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'HTTP_ACCEPT_CHARSET'  => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8',
+            'HTTP_CONTENT_TYPE'    => 'multipart/form-data',
+            'HTTP_HOST'            => 'example.com:8080',
+            'HTTP_USER_AGENT'      => 'Slim Framework',
+            'PHP_AUTH_PW'          => 'sekrit',
+            'PHP_AUTH_USER'        => 'josh',
+            'QUERY_STRING'         => 'abc=123',
+            'REMOTE_ADDR'          => '127.0.0.1',
+            'REQUEST_METHOD'       => 'POST',
+            'REQUEST_TIME'         => time(),
+            'REQUEST_TIME_FLOAT'   => microtime(true),
+            'REQUEST_URI'          => '/foo/bar',
+            'SCRIPT_NAME'          => '/index.php',
+            'SERVER_NAME'          => 'localhost',
+            'SERVER_PORT'          => 8080,
+            'SERVER_PROTOCOL'      => 'HTTP/1.1',
+        ]);
+
+        $_POST = [
+            'def' => '456',
+        ];
+
+        $_FILES = [
+            'uploaded_file' => [
+                'name' => [
+                    0 => 'foo.jpg',
+                    1 => 'bar.jpg',
+                ],
+
+                'type' => [
+                    0 => 'image/jpeg',
+                    1 => 'image/jpeg',
+                ],
+
+                'tmp_name' => [
+                    0 => '/tmp/phpUA3XUw',
+                    1 => '/tmp/phpXUFS0x',
+                ],
+
+                'error' => [
+                    0 => 0,
+                    1 => 0,
+                ],
+
+                'size' => [
+                    0 => 358708,
+                    1 => 236162,
+                ],
+            ]
+        ];
+
+        $request = ServerRequestFactory::createFromGlobals();
+
+        // Ensure method and protocol version are correct
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('1.1', $request->getProtocolVersion());
+
+        // Uri should be set up correctly
+        $uri = $request->getUri();
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+
+        // $_POST should be placed into the parsed body
+        $this->assertEquals($_POST, $request->getParsedBody());
+
+        // $_FILES should be mapped to an array of UploadedFile objects
+        $uploadedFiles = $request->getUploadedFiles();
+        $this->assertCount(1, $uploadedFiles);
+        $this->assertArrayHasKey('uploaded_file', $uploadedFiles);
+        $this->assertInstanceOf(UploadedFile::class, $uploadedFiles['uploaded_file'][0]);
+        $this->assertInstanceOf(UploadedFile::class, $uploadedFiles['uploaded_file'][1]);
     }
 }


### PR DESCRIPTION
This makes it easier to create a Request for use with Slim\App in 4.x which will require a configured `ServerRequest` object:

```php
$request = ServerRequestFactory::createFromGlobals();
```