### PR TITLE
Remove sudo usage from Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 dist: trusty


### PR DESCRIPTION
Due to upcoming Linux infrastructure migration on Travis-CI we need to remove
`sudo: false` from our configuration.