### PR TITLE
Add integration test for request

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -233,16 +233,12 @@ class Request extends Message implements ServerRequestInterface
     /**
      * Validate the HTTP method
      *
-     * @param  null|string $method
+     * @param  string $method
      * @return string
      * @throws \InvalidArgumentException on invalid HTTP method.
      */
     protected function filterMethod($method)
     {
-        if ($method === null) {
-            return '';
-        }
-
         if (!is_string($method)) {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported HTTP method; must be a string, received %s',
@@ -406,9 +402,8 @@ class Request extends Message implements ServerRequestInterface
         if ($query) {
             $path .= '?' . $query;
         }
-        $this->requestTarget = $path;
 
-        return $this->requestTarget;
+        return $path;
     }
 
     /**

--- a/tests/Integration/RequestTest.php
+++ b/tests/Integration/RequestTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim-Psr7
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim-Psr7/blob/master/LICENSE (MIT License)
+ */
+namespace Slim\Tests\Psr7\Integration;
+
+use Http\Psr7Test\RequestIntegrationTest;
+use Psr\Http\Message\RequestInterface;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
+
+class RequestTest extends RequestIntegrationTest
+{
+    use BaseTestFactories;
+
+    /**
+     * @return RequestInterface that is used in the tests
+     */
+    public function createSubject()
+    {
+        return new Request('GET', $this->buildUri('/'), new Headers(), [], [], $this->buildStream(''));
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -91,13 +91,6 @@ class RequestTest extends TestCase
         $this->requestFactory()->withMethod('B@R');
     }
 
-    public function testWithMethodNull()
-    {
-        $request = $this->requestFactory()->withMethod(null);
-
-        $this->assertAttributeEquals(null, 'method', $request);
-    }
-
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
Currently we have an integration test for ServerRequest, but not for Request. This PR adds the missing test and fixes something not compatible.