### PR TITLE
Remove Deprecated Assertion Methods From Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "psr/http-message": "^1.0"
   },
   "require-dev": {
+    "ext-json": "*",
     "http-interop/http-factory-tests": "^0.5.0",
     "php-coveralls/php-coveralls": "^2.1",
     "php-http/psr7-integration-tests": "dev-master",

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -158,8 +158,10 @@ class BodyTest extends TestCase
         $body = new Stream($this->stream);
         $body->close();
 
-        $this->assertAttributeEquals(null, 'stream', $body);
-        //$this->assertFalse($body->isAttached()); #1269
+        $bodyStream = new ReflectionProperty($body, 'stream');
+        $bodyStream->setAccessible(true);
+
+        $this->assertNull($bodyStream->getValue($body));
     }
 
     public function testGetSizeAttached()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -64,21 +64,21 @@ class RequestTest extends TestCase
     {
         $request = $this->requestFactory()->withMethod('PUT');
 
-        $this->assertAttributeEquals('PUT', 'method', $request);
+        $this->assertEquals('PUT', $request->getMethod());
     }
 
     public function testWithMethodCaseSensitive()
     {
         $request = $this->requestFactory()->withMethod('pOsT');
 
-        $this->assertAttributeEquals('pOsT', 'method', $request);
+        $this->assertEquals('pOsT', $request->getMethod());
     }
 
     public function testWithAllAllowedCharactersMethod()
     {
         $request = $this->requestFactory()->withMethod("!#$%&'*+.^_`|~09AZ-");
 
-        $this->assertAttributeEquals("!#$%&'*+.^_`|~09AZ-", 'method', $request);
+        $this->assertEquals("!#$%&'*+.^_`|~09AZ-", $request->getMethod());
     }
 
     /**
@@ -146,7 +146,7 @@ class RequestTest extends TestCase
     {
         $clone = $this->requestFactory()->withRequestTarget('/test?user=1');
 
-        $this->assertAttributeEquals('/test?user=1', 'requestTarget', $clone);
+        $this->assertEquals('/test?user=1', $clone->getRequestTarget());
     }
 
     /**
@@ -183,7 +183,7 @@ class RequestTest extends TestCase
         $request = new Request('GET', $uri1, $headers, $cookies, $serverParams, $body);
         $clone = $request->withUri($uri2);
 
-        $this->assertAttributeSame($uri2, 'uri', $clone);
+        $this->assertSame($uri2, $clone->getUri());
     }
 
     public function testWithUriPreservesHost()
@@ -402,7 +402,6 @@ class RequestTest extends TestCase
         $body = new RequestBody();
         $body->write('foo=bar');
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
-
 
         $clone = $request->withParsedBody([]);
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -28,7 +28,8 @@ class StreamTest extends TestCase
     public function tearDown()
     {
         if ($this->pipeFh != null) {
-            stream_get_contents($this->pipeFh); // prevent broken pipe error message
+            // prevent broken pipe error message
+            stream_get_contents($this->pipeFh);
         }
     }
 
@@ -101,7 +102,9 @@ class StreamTest extends TestCase
     {
         $this->openPipeStream();
 
-        stream_get_contents($this->pipeFh); // prevent broken pipe error message
+        // prevent broken pipe error message
+        stream_get_contents($this->pipeFh);
+
         $this->pipeStream->close();
         $this->pipeFh = null;
 
@@ -123,11 +126,6 @@ class StreamTest extends TestCase
         $this->assertSame('12', $contents);
     }
 
-    /**
-     * Opens the pipe stream
-     *
-     * @see StreamTest::pipeStream
-     */
     private function openPipeStream()
     {
         $this->pipeFh = popen('echo 12', 'r');

--- a/tests/UploadedFilesTest.php
+++ b/tests/UploadedFilesTest.php
@@ -113,7 +113,6 @@ class UploadedFilesTest extends TestCase
             false
         );
 
-
         $this->assertEquals($attr['name'], $uploadedFile->getClientFilename());
         $this->assertEquals($attr['type'], $uploadedFile->getClientMediaType());
         $this->assertEquals($attr['size'], $uploadedFile->getSize());

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -38,21 +38,21 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withScheme('http');
 
-        $this->assertAttributeEquals('http', 'scheme', $uri);
+        $this->assertEquals('http', $uri->getScheme());
     }
 
     public function testWithSchemeRemovesSuffix()
     {
         $uri = $this->uriFactory()->withScheme('http://');
 
-        $this->assertAttributeEquals('http', 'scheme', $uri);
+        $this->assertEquals('http', $uri->getScheme());
     }
 
     public function testWithSchemeEmpty()
     {
         $uri = $this->uriFactory()->withScheme('');
 
-        $this->assertAttributeEquals('', 'scheme', $uri);
+        $this->assertEquals('', $uri->getScheme());
     }
 
     /**
@@ -82,33 +82,29 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withUserInfo('bob', 'pass');
 
-        $this->assertAttributeEquals('bob', 'user', $uri);
-        $this->assertAttributeEquals('pass', 'password', $uri);
+        $this->assertEquals('bob:pass', $uri->getUserInfo());
     }
 
     public function testWithUserInfoEncodesCorrectly()
     {
         $uri = $this->uriFactory()->withUserInfo('bob@example.com', 'pass:word');
 
-        $this->assertAttributeEquals('bob%40example.com', 'user', $uri);
-        $this->assertAttributeEquals('pass%3Aword', 'password', $uri);
+        $this->assertEquals('bob%40example.com:pass%3Aword', $uri->getUserInfo());
     }
 
     public function testWithUserInfoRemovesPassword()
     {
         $uri = $this->uriFactory()->withUserInfo('bob');
 
-        $this->assertAttributeEquals('bob', 'user', $uri);
-        $this->assertAttributeEquals('', 'password', $uri);
+        $this->assertEquals('bob', $uri->getUserInfo());
     }
 
     public function testWithUserInfoRemovesInfo()
     {
         $uri = $this->uriFactory()->withUserInfo('bob', 'password');
-
         $uri = $uri->withUserInfo('');
-        $this->assertAttributeEquals('', 'user', $uri);
-        $this->assertAttributeEquals('', 'password', $uri);
+
+        $this->assertEquals('', $uri->getUserInfo());
     }
 
     public function testGetHost()
@@ -120,7 +116,7 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withHost('slimframework.com');
 
-        $this->assertAttributeEquals('slimframework.com', 'host', $uri);
+        $this->assertEquals('slimframework.com', $uri->getHost());
     }
 
     public function testFilterHost()
@@ -164,14 +160,14 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withPort(8000);
 
-        $this->assertAttributeEquals(8000, 'port', $uri);
+        $this->assertEquals(8000, $uri->getPort());
     }
 
     public function testWithPortNull()
     {
         $uri = $this->uriFactory()->withPort(null);
 
-        $this->assertAttributeEquals(null, 'port', $uri);
+        $this->assertEquals(null, $uri->getPort());
     }
 
     /**
@@ -199,35 +195,35 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withPath('/new');
 
-        $this->assertAttributeEquals('/new', 'path', $uri);
+        $this->assertEquals('/new', $uri->getPath());
     }
 
     public function testWithPathWithoutPrefix()
     {
         $uri = $this->uriFactory()->withPath('new');
 
-        $this->assertAttributeEquals('new', 'path', $uri);
+        $this->assertEquals('new', $uri->getPath());
     }
 
     public function testWithPathEmptyValue()
     {
         $uri = $this->uriFactory()->withPath('');
 
-        $this->assertAttributeEquals('', 'path', $uri);
+        $this->assertEquals('', $uri->getPath());
     }
 
     public function testWithPathUrlEncodesInput()
     {
         $uri = $this->uriFactory()->withPath('/includes?/new');
 
-        $this->assertAttributeEquals('/includes%3F/new', 'path', $uri);
+        $this->assertEquals('/includes%3F/new', $uri->getPath());
     }
 
     public function testWithPathDoesNotDoubleEncodeInput()
     {
         $uri = $this->uriFactory()->withPath('/include%25s/new');
 
-        $this->assertAttributeEquals('/include%25s/new', 'path', $uri);
+        $this->assertEquals('/include%25s/new', $uri->getPath());
     }
 
     /**
@@ -248,28 +244,28 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withQuery('xyz=123');
 
-        $this->assertAttributeEquals('xyz=123', 'query', $uri);
+        $this->assertEquals('xyz=123', $uri->getQuery());
     }
 
     public function testWithQueryRemovesPrefix()
     {
         $uri = $this->uriFactory()->withQuery('?xyz=123');
 
-        $this->assertAttributeEquals('xyz=123', 'query', $uri);
+        $this->assertEquals('xyz=123', $uri->getQuery());
     }
 
     public function testWithQueryEmpty()
     {
         $uri = $this->uriFactory()->withQuery('');
 
-        $this->assertAttributeEquals('', 'query', $uri);
+        $this->assertEquals('', $uri->getQuery());
     }
 
     public function testFilterQuery()
     {
         $uri = $this->uriFactory()->withQuery('?foobar=%match');
 
-        $this->assertAttributeEquals('foobar=%25match', 'query', $uri);
+        $this->assertEquals('foobar=%25match', $uri->getQuery());
     }
 
     /**
@@ -290,21 +286,21 @@ class UriTest extends TestCase
     {
         $uri = $this->uriFactory()->withFragment('other-fragment');
 
-        $this->assertAttributeEquals('other-fragment', 'fragment', $uri);
+        $this->assertEquals('other-fragment', $uri->getFragment());
     }
 
     public function testWithFragmentRemovesPrefix()
     {
         $uri = $this->uriFactory()->withFragment('#other-fragment');
 
-        $this->assertAttributeEquals('other-fragment', 'fragment', $uri);
+        $this->assertEquals('other-fragment', $uri->getFragment());
     }
 
     public function testWithFragmentEmpty()
     {
         $uri = $this->uriFactory()->withFragment('');
 
-        $this->assertAttributeEquals('', 'fragment', $uri);
+        $this->assertEquals('', $uri->getFragment());
     }
 
     /**


### PR DESCRIPTION
Remove all deprecated assertion methods from tests.

- TestCase::assertAttributeEquals()
- TestCase::assertAttributeInstanceOf()
- TestCase::assertAttributeSame()