### PR TITLE
Add test case for Collection::getIterator()

### DIFF
--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -154,4 +154,12 @@ class CollectionTest extends TestCase
         $this->property->setValue($this->bag, ['foo' => 'bar', 'abc' => '123']);
         $this->assertEquals(2, $this->bag->count());
     }
+
+    public function testGetIterator()
+    {
+        $this->property->setValue($this->bag, ['foo' => 'bar', 'abc' => '123']);
+        $iterator = $this->bag->getIterator();
+        $this->assertIsIterable($iterator);
+        $this->assertEquals(['foo' => 'bar', 'abc' => '123'], $iterator->getArrayCopy());
+    }
 }


### PR DESCRIPTION
The test case checks that the result is iterable and that the internal array data equals the original collection array data.