### PR TITLE
Add test case for createResponse() with non-empty reason phrase

### DIFF
--- a/tests/Factory/ResponseFactoryTest.php
+++ b/tests/Factory/ResponseFactoryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Slim\Tests\Psr7\Factory;
 
 use Interop\Http\Factory\ResponseFactoryTestCase;
+use Psr\Http\Message\ResponseInterface;
 use Slim\Psr7\Factory\ResponseFactory;
 
 class ResponseFactoryTest extends ResponseFactoryTestCase
@@ -20,5 +21,28 @@ class ResponseFactoryTest extends ResponseFactoryTestCase
     protected function createResponseFactory()
     {
         return new ResponseFactory();
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @param int $code
+     * @param string $reasonPhrase
+     */
+    protected function assertResponseCodeAndReasonPhrase($response, $code, $reasonPhrase)
+    {
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame($code, $response->getStatusCode());
+        $this->assertSame($reasonPhrase, $response->getReasonPhrase());
+    }
+
+    /**
+     * @dataProvider dataCodes
+     * @param int $code
+     */
+    public function testCreateResponseWithReasonPhrase($code)
+    {
+        $response = $this->factory->createResponse($code, 'Reason');
+        $this->assertResponse($response, $code);
+        $this->assertResponseCodeAndReasonPhrase($response, $code, 'Reason');
     }
 }


### PR DESCRIPTION
Test case for the `ResponseFactory::createResponse()` method in case the reason phrase is non-empty.