### PR TITLE
Add test case to check \Slim\Psr7\Response::filterReasonPhrase()

### DIFF
--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -117,6 +117,18 @@ class ResponseTest extends TestCase
         $this->assertEquals('', $responseWithNoMessage->getReasonPhrase());
     }
 
+    public function testWithStatusValidReasonPhraseObject()
+    {
+        $mock = $this->getMockBuilder('ResponseTestReasonPhrase')->setMethods(['__toString'])->getMock();
+        $mock->expects($this->once())
+            ->method('__toString')
+            ->will($this->returnValue('Slim OK'));
+
+        $response = new Response();
+        $response = $response->withStatus(200, $mock);
+        $this->assertEquals('Slim OK', $response->getReasonPhrase());
+    }
+
     public function testGetReasonPhrase()
     {
         $response = new Response(404);


### PR DESCRIPTION
The test case checks if the method works as expected even when passed a class that defines a `__toString()` method.

Actually, I am using the public `withStatus()` method, which then internally calls the protected method `filterReasonPhrase()`.

Alternatively, we could implement the test case as follows (i.e. using reflection to turn the `filterReasonPhrase()` method into a public method and then call it directly):
```php
    public function testFilterReasonPhraseValidObject()
    {
        $mock = $this->getMockBuilder('ResponseTestReasonPhrase')->setMethods(['__toString'])->getMock();
        $mock->expects($this->once())
            ->method('__toString')
            ->will($this->returnValue('Slim OK'));

        $response = new Response();
        $method = new ReflectionMethod($response, 'filterReasonPhrase');
        $method->setAccessible(true);
        $this->assertEquals('Slim OK', $method->invoke($response, $mock));
    }
```
What do you prefer?