### PR TITLE
Add getallheaders polyfill dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "php-http/psr7-integration-tests": "dev-master",
     "phpstan/phpstan": "^0.10",
     "phpunit/phpunit": "^6.0|^7.0",
-    "squizlabs/php_codesniffer": "^3.3"
+    "squizlabs/php_codesniffer": "^3.3",
+    "ralouphie/getallheaders": "^2"
   },
   "provide": {
     "psr/http-message-implementation": "1.0"


### PR DESCRIPTION
PR for #72. Adding the getallheaders-polyfill to the required development libraries solves phpunit failures on systems without `getallheaders()`.