### PR TITLE
[WIP] Add test cases for \Slim\Psr7\UploadedFile in sapi mode

### DIFF
--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -53,3 +53,20 @@ function header_remove($name = null)
 {
     HeaderStack::remove($name);
 }
+
+/**
+ * @param string $filename
+ *
+ * @return bool
+ */
+function is_uploaded_file(string $filename): bool
+{
+    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+    foreach ($backtrace as $element) {
+        if ($element['function'] === 'testMoveToSapiMoveUploadedFileFails') {
+            return true;
+        }
+    }
+
+    return \is_uploaded_file($filename);
+}

--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -61,11 +61,8 @@ function header_remove($name = null)
  */
 function is_uploaded_file(string $filename): bool
 {
-    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-    foreach ($backtrace as $element) {
-        if ($element['function'] === 'testMoveToSapiMoveUploadedFileFails') {
-            return true;
-        }
+    if (isset($GLOBALS['is_uploaded_file_return'])) {
+        return $GLOBALS['is_uploaded_file_return'];
     }
 
     return \is_uploaded_file($filename);

--- a/tests/UploadedFilesTest.php
+++ b/tests/UploadedFilesTest.php
@@ -39,6 +39,13 @@ class UploadedFilesTest extends TestCase
         }
     }
 
+    public function tearDown()
+    {
+        if (isset($GLOBALS['is_uploaded_file_return'])) {
+            unset($GLOBALS['is_uploaded_file_return']);
+        }
+    }
+
     /**
      * @return UploadedFile
      */
@@ -225,6 +232,8 @@ class UploadedFilesTest extends TestCase
      */
     public function testMoveToSapiMoveUploadedFileFails(UploadedFile $uploadedFile)
     {
+        $GLOBALS['is_uploaded_file_return'] = true;
+
         $tempName = uniqid('file-');
         $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $tempName;
         $uploadedFile->moveTo($path);

--- a/tests/UploadedFilesTest.php
+++ b/tests/UploadedFilesTest.php
@@ -122,6 +122,36 @@ class UploadedFilesTest extends TestCase
     }
 
     /**
+     * @return UploadedFile
+     */
+    public function testConstructorSapi()
+    {
+        $attr = [
+            'tmp_name' => self::$filename,
+            'name' => 'my-avatar.txt',
+            'size' => 8,
+            'type' => 'text/plain',
+            'error' => 0,
+        ];
+
+        $uploadedFile = new UploadedFile(
+            $attr['tmp_name'],
+            $attr['name'],
+            $attr['type'],
+            $attr['size'],
+            $attr['error'],
+            true
+        );
+
+        $this->assertEquals($attr['name'], $uploadedFile->getClientFilename());
+        $this->assertEquals($attr['type'], $uploadedFile->getClientMediaType());
+        $this->assertEquals($attr['size'], $uploadedFile->getSize());
+        $this->assertEquals($attr['error'], $uploadedFile->getError());
+
+        return $uploadedFile;
+    }
+
+    /**
      * @depends testConstructor
      *
      * @param UploadedFile $uploadedFile
@@ -169,6 +199,35 @@ class UploadedFilesTest extends TestCase
         unlink($path);
 
         return $uploadedFile;
+    }
+
+    /**
+     * @depends testConstructorSapi
+     *
+     * @param UploadedFile $uploadedFile
+     *
+     * @expectedException RuntimeException
+     */
+    public function testMoveToSapiNonUploadedFile(UploadedFile $uploadedFile)
+    {
+        $tempName = uniqid('file-');
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $tempName;
+        $uploadedFile->moveTo($path);
+    }
+
+    /**
+     * @depends testConstructorSapi
+     *
+     * @param UploadedFile $uploadedFile
+     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessageRegExp ~Error moving uploaded file.*~
+     */
+    public function testMoveToSapiMoveUploadedFileFails(UploadedFile $uploadedFile)
+    {
+        $tempName = uniqid('file-');
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $tempName;
+        $uploadedFile->moveTo($path);
     }
 
     /**


### PR DESCRIPTION
Two test cases for `\Slim\Psr7\UploadedFile` in sapi mode.

The `testMoveToSapiNonUploadedFile` checks whether the `moveTo` method would throw an exception if the file is not an uploaded file. This test case works - nothing special there.

The `testMoveToSapiMoveUploadedFileFails` checks whether the `moveTo` method would throw an exception if the file is an uploaded file but could not be moved. For this test case I had to override the function `is_uploaded_file()` (`tests/Assets/PhpFunctionOverrides.php`) such that it returns `true` if called via `testMoveToSapiMoveUploadedFileFails`. First I tried to use the `$GLOBALS`-strategy (which means set a return value for the overridden function before calling the method and then unset the return value after calling the method). But that did not work, because there is no "after calling the method" as the method would throw an exception which the test is actually waiting for.

Another solution would be, using try-catch in the test case and unset the `$GLOBALS` return value in the catch block. Eventually throw the caught exception again.

Do you have any other idea, how this could be implemented? Best practice?