### PR TITLE
Test case for \Slim\Psr7\NonBufferedBody::write()

### DIFF
--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -69,17 +69,15 @@ function is_uploaded_file(string $filename): bool
 }
 
 /**
- * Return the value of the global variable $GLOBALS['ob_get_level_return'] if it
- * exists. Otherwise the function override calls the default php built-in
- * function.
+ * Return the level of the output buffering shifted by the value of the global
+ * variable $GLOBALS['ob_get_level_shift'] if it exists. Otherwise the function
+ * override calls the default php built-in function.
  *
  * @return int
  */
 function ob_get_level(): int
 {
-
     if (isset($GLOBALS['ob_get_level_shift'])) {
-        file_put_contents('C:\Users\Adrian\Desktop\test.txt', \ob_get_level() + $GLOBALS['ob_get_level_shift']);
         return \ob_get_level() + $GLOBALS['ob_get_level_shift'];
     }
 

--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -67,3 +67,21 @@ function is_uploaded_file(string $filename): bool
 
     return \is_uploaded_file($filename);
 }
+
+/**
+ * Return the value of the global variable $GLOBALS['ob_get_level_return'] if it
+ * exists. Otherwise the function override calls the default php built-in
+ * function.
+ *
+ * @return int
+ */
+function ob_get_level(): int
+{
+
+    if (isset($GLOBALS['ob_get_level_shift'])) {
+        file_put_contents('C:\Users\Adrian\Desktop\test.txt', \ob_get_level() + $GLOBALS['ob_get_level_shift']);
+        return \ob_get_level() + $GLOBALS['ob_get_level_shift'];
+    }
+
+    return \ob_get_level();
+}

--- a/tests/NonBufferedBodyTest.php
+++ b/tests/NonBufferedBodyTest.php
@@ -68,8 +68,8 @@ class NonBufferedBodyTest extends TestCase
         unset($GLOBALS['ob_get_level_shift']);
         $contents = ob_get_clean();
 
-        $this->assertEquals(16 + 6, $length0);
-        $this->assertEquals(5, $length1);
+        $this->assertEquals(strlen('buffer content: ') + strlen('hello '), $length0);
+        $this->assertEquals(strlen('world'), $length1);
         $this->assertEquals('buffer content: hello world', $contents);
     }
 

--- a/tests/NonBufferedBodyTest.php
+++ b/tests/NonBufferedBodyTest.php
@@ -42,6 +42,16 @@ class NonBufferedBodyTest extends TestCase
         self::assertNull($body->getMetadata(), 'Metadata mechanism is not implemented');
     }
 
+    public function testWrite()
+    {
+        $body = new NonBufferedBody();
+        $length0 = $body->write('hello ');
+        $length1 = $body->write('world');
+
+        $this->assertEquals(6, $length0);
+        $this->assertEquals(5, $length1);
+    }
+
     public function testWithHeader()
     {
         (new Response())


### PR DESCRIPTION
This test case tests the `write()` method of the `\Slim\Psr7\NonBufferedBody` class. It needs to override the php built-in function `ob_get_level()`.