### PR TITLE
Remove empty reason phrase check

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -154,10 +154,6 @@ class Response extends Message implements ResponseInterface
             $reasonPhrase = static::$messages[$code];
         }
 
-        if ($reasonPhrase === '') {
-            throw new InvalidArgumentException('Reason phrase must be supplied for this status code.');
-        }
-
         $clone->reasonPhrase = $reasonPhrase;
 
         return $clone;
@@ -168,7 +164,7 @@ class Response extends Message implements ResponseInterface
      */
     public function getReasonPhrase(): string
     {
-        if ($this->reasonPhrase) {
+        if ($this->reasonPhrase !== '') {
             return $this->reasonPhrase;
         }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -136,14 +136,12 @@ class ResponseTest extends TestCase
         $this->assertEquals('Not Found', $response->getReasonPhrase());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Reason phrase must be supplied for this status code
-     */
-    public function testMustSetReasonPhraseForUnrecognisedCode()
+    public function testEmptyReasonPhraseForUnrecognisedCode()
     {
         $response = new Response();
-        $response->withStatus(199);
+        $response = $response->withStatus(199);
+        
+        $this->assertSame('', $response->getReasonPhrase());
     }
 
     public function testSetReasonPhraseForUnrecognisedCode()


### PR DESCRIPTION
The reason phrase is entirely optional and this behavior violates both HTTP/1.1 and PSR-7.

Additionally, the check in `getReasonPhrase` got removed to allow for a reason phrase of '0' instead of falling back to the default.