### PR TITLE
UploadedFileFactory - Failing to create a readable UploadedFile from string

### DIFF
--- a/src/Factory/UploadedFileFactory.php
+++ b/src/Factory/UploadedFileFactory.php
@@ -29,7 +29,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
     ): UploadedFileInterface {
         $file = $stream->getMetadata('uri');
 
-        if (!is_string($file) || !is_readable($file)) {
+        if (!is_string($file) || !$stream->isReadable()) {
             throw new InvalidArgumentException('File is not readable.');
         }
 
@@ -37,6 +37,6 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
             $size = $stream->getSize();
         }
 
-        return new UploadedFile($file, $clientFilename, $clientMediaType, $size, $error);
+        return new UploadedFile($stream, $clientFilename, $clientMediaType, $size, $error);
     }
 }

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -70,22 +70,36 @@ class UploadedFile implements UploadedFileInterface
     protected $moved = false;
 
     /**
-     * @param string      $file  The full path to the uploaded file provided by the client.
-     * @param string|null $name  The file name.
-     * @param string|null $type  The file media type.
-     * @param int|null    $size  The file size in bytes.
-     * @param int         $error The UPLOAD_ERR_XXX code representing the status of the upload.
-     * @param bool        $sapi  Indicates if the upload is in a SAPI environment.
+     * @param string|StreamInterface $fileNameOrStream The full path to the uploaded file provided by the client,
+     *                                                 or a StreamInterface instance.
+     * @param string|null            $name             The file name.
+     * @param string|null            $type             The file media type.
+     * @param int|null               $size             The file size in bytes.
+     * @param int                    $error            The UPLOAD_ERR_XXX code representing the status of the upload.
+     * @param bool                   $sapi             Indicates if the upload is in a SAPI environment.
      */
     public function __construct(
-        string $file,
+        $fileNameOrStream,
         ?string $name = null,
         ?string $type = null,
         ?int $size = null,
         int $error = UPLOAD_ERR_OK,
         bool $sapi = false
     ) {
-        $this->file = $file;
+        if ($fileNameOrStream instanceof StreamInterface) {
+            $file = $fileNameOrStream->getMetadata('uri');
+            if (!is_string($file)) {
+                throw new InvalidArgumentException('No URI associated with the stream.');
+            }
+            $this->file = $file;
+            $this->stream = $fileNameOrStream;
+        } elseif (is_string($fileNameOrStream)) {
+            $this->file = $fileNameOrStream;
+        } else {
+            throw new InvalidArgumentException(
+                'Please provide a string (full path to the uploaded file) or an instance of StreamInterface.'
+            );
+        }
         $this->name = $name;
         $this->type = $type;
         $this->size = $size;

--- a/tests/Factory/UploadedFileFactoryTest.php
+++ b/tests/Factory/UploadedFileFactoryTest.php
@@ -68,9 +68,19 @@ class UploadedFileFactoryTest extends UploadedFileFactoryTestCase
      */
     public function testCreateUploadedFileWithInvalidUri()
     {
-        $this->factory->createUploadedFile(
-            $this->prophesizeStreamInterfaceWithGetMetadataMethod('uri', null)
-        );
+        // Prophesize a `\Psr\Http\Message\StreamInterface` with a `getMetadata` method prophecy.
+        $streamProphecy = $this->prophesize(StreamInterface::class);
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $streamProphecy
+            ->getMetadata('uri')
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        /** @var StreamInterface $stream */
+        $stream = $streamProphecy->reveal();
+
+        $this->factory->createUploadedFile($stream);
     }
 
     /**
@@ -79,8 +89,24 @@ class UploadedFileFactoryTest extends UploadedFileFactoryTestCase
      */
     public function testCreateUploadedFileWithNonReadableFile()
     {
-        $this->factory->createUploadedFile(
-            $this->prophesizeStreamInterfaceWithGetMetadataMethod('uri', 'non-readable')
-        );
+        // Prophesize a `\Psr\Http\Message\StreamInterface` with a `getMetadata` and `isReadable` method prophecies.
+        $streamProphecy = $this->prophesize(StreamInterface::class);
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $streamProphecy
+            ->getMetadata('uri')
+            ->willReturn('non-readable')
+            ->shouldBeCalled();
+
+        /** @noinspection PhpUndefinedMethodInspection */
+        $streamProphecy
+            ->isReadable()
+            ->willReturn(false)
+            ->shouldBeCalled();
+
+        /** @var StreamInterface $stream */
+        $stream = $streamProphecy->reveal();
+
+        $this->factory->createUploadedFile($stream);
     }
 }


### PR DESCRIPTION
While I was updating Mika Tuupola's `tuupola/http-factory` to support this package, I stumbled upon this bug. The tests won't pass for `slim/psr7` as can be seen here https://github.com/tuupola/http-factory/pull/10, while they do pass for the other PSR-7 implementations.

I was trying to solve it for a couple of hours, but failed, so for now I'm just providing the failing test and a temporary comparison to `nyholm/psr7` that does not fail.

The code of the test is taken from `Interop\Http\Factory\UploadedFileFactoryTestCase` (`http-interop/http-factory-tests` package).

I will try a bit later again, but I suspect the authors will have much better insight into the matter.