### PR TITLE
Remove redundant checks

### DIFF
--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -49,7 +49,7 @@ class StreamFactory implements StreamFactoryInterface
             );
         }
 
-        return $this->createStreamFromResource($resource);
+        return new Stream($resource);
     }
 
     /**


### PR DESCRIPTION
Redundant sequential checks spawn unreachable code. The method call `createStreamFromFile` checks the argument three times : is_resource -> is_resource -> is_resource