### PR TITLE
Add withServerParams() API to Slim PSR-7 request objects.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -304,6 +304,18 @@ class Request extends Message implements ServerRequestInterface
     }
 
     /**
+     * @param array $serverParams
+     * @return self
+     */
+    public function withServerParams(array $serverParams): self
+    {
+        $clone = clone $this;
+        $clone->serverParams = $serverParams;
+
+        return $clone;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getAttributes(): array

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -457,4 +457,16 @@ class RequestTest extends TestCase
     {
         $this->requestFactory()->withParsedBody(false);
     }
+
+    public function testWithServerParamsOverwrites()
+    {
+        $request = $this->requestFactory();
+
+        $params = $request->getServerParams();
+        $params['HTTP_SOATOK'] = 'unit test';
+        $cloned = $request->withServerParams($params);
+
+        $this->assertSame('unit test', $cloned->getServerParams()['HTTP_SOATOK']);
+        $this->assertFalse(array_key_exists('HTTP_SOATOK', $request->getServerParams()));
+    }
 }


### PR DESCRIPTION
This was missing from the latest release, although I expected it to exist. I mostly need it for unit tests, but I also wrote [an IP address anonymizer](https://github.com/soatok/anthrokit/blob/master/src/Privacy.php) that might work well with Slim's PSR-7 library.