### PR TITLE
Fix test ServerRequestTest::testGetUploadedFiles

### DIFF
--- a/tests/Integration/BaseTestFactories.php
+++ b/tests/Integration/BaseTestFactories.php
@@ -42,11 +42,11 @@ trait BaseTestFactories
     }
 
     /**
-     * @param string $file
+     * @param $data
      * @return UploadedFile
      */
-    protected function buildUploadedFile(string $file): UploadedFile
+    protected function buildUploadableFile($data): UploadedFile
     {
-        return new UploadedFile($file);
+        return new UploadedFile($this->buildStream($data));
     }
 }


### PR DESCRIPTION
Fixed an unit tests which was suddenly failing on my local machine for reason:

> There was 1 error:
> 
> 1) Slim\Tests\Psr7\Integration\ServerRequestTest::testGetUploadedFiles
RuntimeException: Could not create Stream. Check your config
> 
> /data/workspace/Slim-Psr7/vendor/php-http/psr7-integration-tests/src/BaseTest.php:111
> /data/workspace/Slim-Psr7/vendor/php-http/psr7-integration-tests/src/ServerRequestIntegrationTest.php:83