### PR TITLE
Upgrade getallheaders polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "fig/http-message-util":  "^1.1",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
-    "ralouphie/getallheaders": "^2"
+    "ralouphie/getallheaders": "^3"
   },
   "require-dev": {
     "ext-json": "*",


### PR DESCRIPTION
Upgrade from v2 to v3 here since we are on PHP 7+

> Install
> For PHP version >= 5.6:
>
> composer require ralouphie/getallheaders
> For PHP version < 5.6:
>
> composer require ralouphie/getallheaders "^2"
> (https://github.com/ralouphie/getallheaders#install)