### PR TITLE
Remove useless logic condition

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -185,7 +185,7 @@ class Stream implements StreamInterface
             $position = ftell($this->stream);
         }
 
-        if (!$this->stream || $position === false || $this->isPipe()) {
+        if ($position === false || $this->isPipe()) {
             throw new RuntimeException('Could not get the position of the pointer in stream.');
         }
 


### PR DESCRIPTION
The null-stream can be tracked through `position === false`