### PR TITLE
Reduce method responsibility

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -149,11 +149,6 @@ class Response extends Message implements ResponseInterface
 
         $clone = clone $this;
         $clone->status = $code;
-
-        if ($reasonPhrase === '' && isset(static::$messages[$code])) {
-            $reasonPhrase = static::$messages[$code];
-        }
-
         $clone->reasonPhrase = $reasonPhrase;
 
         return $clone;


### PR DESCRIPTION
When we create an object through the `Response` constructor
```php
$response = new Response(200)
// protected $this->status = 200
// protected $this->reasonPhrase = '', by default
```
we don't attempt to guess(set) the value of the reason phrase. We are just using default value(empty string). All needed work is done by the `getReasonPhrase` method. It maps a status to a reason.

On the other hand, when we call the `withStatus` method we have a different strategy
```php
$forbidden = new Response(403);
// ...
$ok = $forbidden->withStatus(200);
// protected $this->status = 200;
// protected $this->reasonPhrase = 'OK'
```
I suggest to rely on the work of the `getReasonPhrase` method;