### PR TITLE
cause status code 418 was added in 1.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": "^7.1",
-    "fig/http-message-util":  "^1.1",
+    "fig/http-message-util":  "^1.1.2",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
     "ralouphie/getallheaders": "^3"


### PR DESCRIPTION
Found within my testsuite: https://travis-ci.org/chubbyphp/petstore/jobs/567561612

Fatal error: Uncaught Error: Undefined class constant 'Fig\Http\Message\StatusCodeInterface::STATUS_IM_A_TEAPOT'

=> 1.1.1

Fatal error: Uncaught Error: Undefined class constant 'Fig\Http\Message\StatusCodeInterface::STATUS_MISDIRECTED_REQUEST'

=> 1.1.2
