### PR TITLE
LSP violation

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -37,7 +37,7 @@ class Headers implements HeadersInterface
     /**
      * {@inheritdoc}
      */
-    public function addHeader(string $name, $value): HeadersInterface
+    public function addHeader($name, $value): HeadersInterface
     {
         [$values, $originalName, $normalizedName] = $this->prepareHeader($name, $value);
 
@@ -84,7 +84,7 @@ class Headers implements HeadersInterface
     /**
      * {@inheritdoc}
      */
-    public function setHeader(string $name, $value): HeadersInterface
+    public function setHeader($name, $value): HeadersInterface
     {
         [$values, $originalName, $normalizedName] = $this->prepareHeader($name, $value);
 
@@ -202,7 +202,7 @@ class Headers implements HeadersInterface
      *
      * @return array
      */
-    protected function prepareHeader(string $name, $value): array
+    protected function prepareHeader($name, $value): array
     {
         $this->validateHeader($name, $value);
         $values = $this->trimHeaderValue($value);
@@ -234,10 +234,10 @@ class Headers implements HeadersInterface
      *
      * @throws InvalidArgumentException;
      */
-    protected function validateHeader(string $name, $value)
+    protected function validateHeader($name, $value)
     {
-        self::validateHeaderName($name);
-        self::validateHeaderValue($value);
+        $this->validateHeaderName($name);
+        $this->validateHeaderValue($value);
     }
 
     /**
@@ -245,7 +245,7 @@ class Headers implements HeadersInterface
      *
      * @throws InvalidArgumentException
      */
-    public static function validateHeaderName($name)
+    protected function validateHeaderName($name)
     {
         if (!is_string($name) || preg_match("@^[!#$%&'*+.^_`|~0-9A-Za-z-]+$@", $name) !== 1) {
             throw new InvalidArgumentException('Header name must be an RFC 7230 compatible string.');
@@ -257,7 +257,7 @@ class Headers implements HeadersInterface
      *
      * @throws InvalidArgumentException
      */
-    public static function validateHeaderValue($value)
+    protected function validateHeaderValue($value)
     {
         $items = is_array($value) ? $value : [$value];
 

--- a/src/Interfaces/HeadersInterface.php
+++ b/src/Interfaces/HeadersInterface.php
@@ -25,7 +25,7 @@ interface HeadersInterface
      *
      * @throws InvalidArgumentException
      */
-    public function addHeader(string $name, $value): HeadersInterface;
+    public function addHeader($name, $value): HeadersInterface;
 
     /**
      * Remove header value
@@ -57,7 +57,7 @@ interface HeadersInterface
      *
      * @throws InvalidArgumentException
      */
-    public function setHeader(string $name, $value): HeadersInterface;
+    public function setHeader($name, $value): HeadersInterface;
 
     /**
      * Replaces all existing headers with the new values.

--- a/src/Message.php
+++ b/src/Message.php
@@ -118,9 +118,6 @@ abstract class Message implements MessageInterface
      */
     public function withHeader($name, $value)
     {
-        Headers::validateHeaderName($name);
-        Headers::validateHeaderValue($value);
-
         $clone = clone $this;
         $clone->headers->setHeader($name, $value);
 
@@ -136,9 +133,6 @@ abstract class Message implements MessageInterface
      */
     public function withAddedHeader($name, $value)
     {
-        Headers::validateHeaderName($name);
-        Headers::validateHeaderValue($value);
-
         $clone = clone $this;
         $clone->headers->addHeader($name, $value);
 


### PR DESCRIPTION
Suppose we have a function `f` that perfectly works with some domain of values called `A`.
`[Domain A/input] -> f -> [Codomain A/output]`
At the same time, we have another function `g` that works fine with another domain of values called `B`.
`[Domain B/input] -> g -> [Codomain B/output]`
The function `f` can safely replace the function `g` if and only if the domain `B` is a subset of the domain `A` && the codomain `A` is a subset of the codomain `B`.
Let's look at the following signatures
- `Headers::setHeader(string $name, ...)` - `f`(domain `A` is string type)
- `Message::withHeader($name, ...)`       - `g`(domain `B` is any type)

When we do something like this `$response->withHeader($any, ...)` we violate the above principle. The specified method call is transformed to `$this->headers->setHeader($any, ...)`.
The domain `A` (string type) is less than the domain `B` (any type). For this reason, unnecessary static methods had to be implemented [causing a problem](https://github.com/slimphp/Slim-Psr7/issues/117).