### PR TITLE
Add support for caching the underlying stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: trusty
 matrix:
   include:
     - php: 7.1
-      env: ANALYSIS='true'
     - php: 7.2
     - php: 7.3
+      env: ANALYSIS='true'
     - php: nightly
   allow_failures:
     - php: nightly

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -90,7 +90,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         $headers = Headers::createFromGlobals();
         $cookies = Cookies::parseHeader($headers->getHeader('Cookie', []));
 
-        $body = (new StreamFactory())->createStreamFromFile('php://input');
+        $body = (new StreamFactory())->createStreamFromFile('php://input', 'r', true);
         $uploadedFiles = UploadedFile::createFromGlobals($_SERVER);
 
         $request = new Request($method, $uri, $headers, $cookies, $_SERVER, $body, $uploadedFiles);

--- a/src/Factory/ServerRequestFactory.php
+++ b/src/Factory/ServerRequestFactory.php
@@ -18,6 +18,7 @@ use Psr\Http\Message\UriInterface;
 use Slim\Psr7\Cookies;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request;
+use Slim\Psr7\Stream;
 use Slim\Psr7\UploadedFile;
 
 class ServerRequestFactory implements ServerRequestFactoryInterface
@@ -90,7 +91,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         $headers = Headers::createFromGlobals();
         $cookies = Cookies::parseHeader($headers->getHeader('Cookie', []));
 
-        $body = (new StreamFactory())->createStreamFromFile('php://input', 'r', true);
+        // Cache the php://input stream as it cannot be re-read
+        $cacheResource = fopen('php://temp', 'wb+');
+        $cache = $cacheResource ? new Stream($cacheResource) : null;
+
+        $body = (new StreamFactory())->createStreamFromFile('php://input', 'r', $cache);
         $uploadedFiles = UploadedFile::createFromGlobals($_SERVER);
 
         $request = new Request($method, $uri, $headers, $cookies, $_SERVER, $body, $uploadedFiles);

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -39,8 +39,11 @@ class StreamFactory implements StreamFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
-    {
+    public function createStreamFromFile(
+        string $filename,
+        string $mode = 'r',
+        bool $cacheStream = false
+    ): StreamInterface {
         $resource = fopen($filename, $mode);
 
         if (!is_resource($resource)) {
@@ -49,13 +52,13 @@ class StreamFactory implements StreamFactoryInterface
             );
         }
 
-        return new Stream($resource);
+        return new Stream($resource, $cacheStream);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createStreamFromResource($resource): StreamInterface
+    public function createStreamFromResource($resource, bool $cacheStream = false): StreamInterface
     {
         if (!is_resource($resource)) {
             throw new InvalidArgumentException(
@@ -63,6 +66,6 @@ class StreamFactory implements StreamFactoryInterface
             );
         }
 
-        return new Stream($resource);
+        return new Stream($resource, $cacheStream);
     }
 }

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -42,7 +42,7 @@ class StreamFactory implements StreamFactoryInterface
     public function createStreamFromFile(
         string $filename,
         string $mode = 'r',
-        bool $cacheStream = false
+        StreamInterface $cache = null
     ): StreamInterface {
         $resource = fopen($filename, $mode);
 
@@ -52,13 +52,13 @@ class StreamFactory implements StreamFactoryInterface
             );
         }
 
-        return new Stream($resource, $cacheStream);
+        return new Stream($resource, $cache);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function createStreamFromResource($resource, bool $cacheStream = false): StreamInterface
+    public function createStreamFromResource($resource, StreamInterface $cache = null): StreamInterface
     {
         if (!is_resource($resource)) {
             throw new InvalidArgumentException(
@@ -66,6 +66,6 @@ class StreamFactory implements StreamFactoryInterface
             );
         }
 
-        return new Stream($resource, $cacheStream);
+        return new Stream($resource, $cache);
     }
 }

--- a/tests/Factory/ServerRequestFactoryTest.php
+++ b/tests/Factory/ServerRequestFactoryTest.php
@@ -116,14 +116,19 @@ class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
         $request = ServerRequestFactory::createFromGlobals();
 
         $this->assertEquals('php://input', $request->getBody()->getMetadata('uri'));
+    }
 
-        // ensure that the Stream's $cacheStream property has been set to true for this php://input stream
+    public function testCreateFromGlobalsSetsACache()
+    {
+        $request = ServerRequestFactory::createFromGlobals();
+
+        // ensure that the Stream's $cache property has been set for this php://input stream
         $stream = $request->getBody();
         $class = new ReflectionClass($stream);
-        $property = $class->getProperty('cacheStream');
+        $property = $class->getProperty('cache');
         $property->setAccessible(true);
         $cacheStreamValue = $property->getValue($stream);
-        $this->assertTrue($cacheStreamValue);
+        $this->assertNotNull($cacheStreamValue);
     }
 
     public function testCreateFromGlobalsWithUploadedFiles()

--- a/tests/Factory/ServerRequestFactoryTest.php
+++ b/tests/Factory/ServerRequestFactoryTest.php
@@ -12,6 +12,7 @@ namespace Slim\Tests\Psr7\Factory;
 use Interop\Http\Factory\ServerRequestFactoryTestCase;
 use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
+use ReflectionClass;
 use Slim\Psr7\Environment;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use Slim\Psr7\Factory\UriFactory;
@@ -115,6 +116,14 @@ class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
         $request = ServerRequestFactory::createFromGlobals();
 
         $this->assertEquals('php://input', $request->getBody()->getMetadata('uri'));
+
+        // ensure that the Stream's $cacheStream property has been set to true for this php://input stream
+        $stream = $request->getBody();
+        $class = new ReflectionClass($stream);
+        $property = $class->getProperty('cacheStream');
+        $property->setAccessible(true);
+        $cacheStreamValue = $property->getValue($stream);
+        $this->assertTrue($cacheStreamValue);
     }
 
     public function testCreateFromGlobalsWithUploadedFiles()

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -201,4 +201,23 @@ class StreamTest extends TestCase
         $this->pipeFh = popen('echo 12', 'r');
         $this->pipeStream = new Stream($this->pipeFh);
     }
+
+
+    public function testCachedStreamsGetsContentFromTheCache()
+    {
+        $resource = popen('echo HelloWorld', 'r');
+        $stream = new Stream($resource, true);
+
+        $this->assertEquals("HelloWorld\n", $stream->getContents());
+        $this->assertEquals("HelloWorld\n", $stream->getContents());
+    }
+
+    public function testCachedStreamsFillsCacheOnRead()
+    {
+        $resource = fopen('data://,0', 'r');
+        $stream = new Stream($resource, true);
+
+        $this->assertEquals("0", $stream->read(100));
+        $this->assertEquals("0", $stream->__toString());
+    }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -202,11 +202,31 @@ class StreamTest extends TestCase
         $this->pipeStream = new Stream($this->pipeFh);
     }
 
+    public function testReadOnlyCachedStreamsAreDisallowed()
+    {
+        $resource = fopen('php://temp', 'w+');
+        $cache =  new Stream(fopen('php://temp', 'r'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cache stream must be seekable and writable');
+        new Stream($resource, $cache);
+    }
+
+    public function testNonSeekableCachedStreamsAreDisallowed()
+    {
+        $resource = fopen('php://temp', 'w+');
+        $cache =  new Stream(fopen('php://output', 'w'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cache stream must be seekable and writable');
+
+        new Stream($resource, $cache);
+    }
 
     public function testCachedStreamsGetsContentFromTheCache()
     {
         $resource = popen('echo HelloWorld', 'r');
-        $stream = new Stream($resource, true);
+        $stream = new Stream($resource, new Stream(fopen('php://temp', 'w+')));
 
         $this->assertEquals("HelloWorld\n", $stream->getContents());
         $this->assertEquals("HelloWorld\n", $stream->getContents());
@@ -215,7 +235,7 @@ class StreamTest extends TestCase
     public function testCachedStreamsFillsCacheOnRead()
     {
         $resource = fopen('data://,0', 'r');
-        $stream = new Stream($resource, true);
+        $stream = new Stream($resource, new Stream(fopen('php://temp', 'w+')));
 
         $this->assertEquals("0", $stream->read(100));
         $this->assertEquals("0", $stream->__toString());


### PR DESCRIPTION
While php://input is seekable, you can't re-read it a second time. This is problematic when you want to parse the body for `getParsedBody()`, but also allow subsequent uses of `getBody()` to work.

To address this, we now allow `Stream` to optionally cache the data it reads (via `read()` or `getContents()`. Then, once the eof is detected, we return the cached data on subsequent `getContents()` calls so that the stream is not read a second time.

Also, update `ServerRequestFactory` so that when it creates a stream for php://input, it enables the caching mechanism.