### PR TITLE
Require tests to pass on PHP 7.4 now that phpspec/prophecy is compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
     - php: 7.4snapshot
     - php: nightly
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
 
 before_script:


### PR DESCRIPTION
Closes #126