### PR TITLE
Add test case to test rewind of cached streams

### DIFF
--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -268,4 +268,14 @@ class StreamTest extends TestCase
         $this->assertNull($cacheProperty->getValue($stream));
         $this->assertFalse($finishedProperty->getValue($stream));
     }
+
+    public function testCachedStreamsRewindIfFinishedOnToString()
+    {
+        $resource = fopen('data://,foo', 'r');
+
+        $stream = new Stream($resource, new Stream(fopen('php://temp', 'w+')));
+
+        $this->assertEquals('foo', (string)$stream);
+        $this->assertEquals('foo', (string)$stream);
+    }
 }


### PR DESCRIPTION
This test case tests the following block:
https://github.com/slimphp/Slim-Psr7/blob/23015a8814382c244315602d44cb02d412b6b059/src/Stream.php#L158-L161