### PR TITLE
`UploadedFile::moveTo()` test cases for php overrides `copy` and `rename`

### DIFF
--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -83,3 +83,41 @@ function ob_get_level(): int
 
     return \ob_get_level();
 }
+
+/**
+ * @param string        $source
+ * @param string        $destination
+ * @param resource|null $context
+ *
+ * @return bool
+ */
+function copy(string $source, string $destination, $context = null): bool
+{
+    if (isset($GLOBALS['copy_return'])) {
+        return $GLOBALS['copy_return'];
+    }
+
+    if ($context === null) {
+        return \copy($source, $destination);
+    }
+    return \copy($source, $destination, $context);
+}
+
+/**
+ * @param string        $oldName
+ * @param string        $newName
+ * @param resource|null $context
+ *
+ * @return bool
+ */
+function rename(string $oldName, string $newName, $context = null): bool
+{
+    if (isset($GLOBALS['rename_return'])) {
+        return $GLOBALS['rename_return'];
+    }
+
+    if ($context === null) {
+        return \rename($oldName, $newName);
+    }
+    return \rename($oldName, $newName, $context = null);
+}

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -48,6 +48,12 @@ class UploadedFileTest extends TestCase
         if (isset($GLOBALS['is_uploaded_file_return'])) {
             unset($GLOBALS['is_uploaded_file_return']);
         }
+        if (isset($GLOBALS['copy_return'])) {
+            unset($GLOBALS['copy_return']);
+        }
+        if (isset($GLOBALS['rename_return'])) {
+            unset($GLOBALS['rename_return']);
+        }
     }
 
     /**
@@ -213,6 +219,21 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessageRegExp /^Error moving uploaded file .* to .*$/
+     */
+    public function testMoveToRenameFailure()
+    {
+        $uploadedFile = $this->generateNewTmpFile();
+
+        $tempName = uniqid('file-');
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $tempName;
+
+        $GLOBALS['rename_return'] = false;
+        $uploadedFile->moveTo($path);
+    }
+
+    /**
      * @depends testConstructorSapi
      *
      * @param UploadedFile $uploadedFile
@@ -307,6 +328,18 @@ class UploadedFileTest extends TestCase
 
         $this->assertEquals($contents, $movedFileContents);
         $this->assertFileNotExists($fileName);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Error moving uploaded file  to php://output
+     */
+    public function testMoveToStreamCopyFailure()
+    {
+        $uploadedFile = $this->generateNewTmpFile();
+
+        $GLOBALS['copy_return'] = false;
+        $uploadedFile->moveTo('php://output');
     }
 
     public function testFileUploadWithTempStream()


### PR DESCRIPTION
This PR adds two test cases for the `\Slim\Psr7\UploadedFile::moveTo()` method.