### PR TITLE
Update php-autoload-override version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   },
   "require-dev": {
     "ext-json": "*",
-    "adriansuter/php-autoload-override": "v0.1-beta",
+    "adriansuter/php-autoload-override": "^1.0",
     "http-interop/http-factory-tests": "^0.6.0",
     "php-http/psr7-integration-tests": "dev-master",
     "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
This PR updates the version for the php-autoload-override library.