### PR TITLE
Patch cookies `get()` method in case a value is `null`

### DIFF
--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -12,6 +12,7 @@ namespace Slim\Psr7;
 
 use InvalidArgumentException;
 
+use function array_key_exists;
 use function array_replace;
 use function count;
 use function explode;
@@ -89,7 +90,7 @@ class Cookies
      */
     public function get(string $name, $default = null)
     {
-        return isset($this->requestCookies[$name]) ? $this->requestCookies[$name] : $default;
+        return array_key_exists($name, $this->requestCookies) ? $this->requestCookies[$name] : $default;
     }
 
     /**

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -189,8 +189,9 @@ class CookiesTest extends TestCase
 
     public function testGet()
     {
-        $cookies = new Cookies(['foo' => 'bar']);
+        $cookies = new Cookies(['foo' => 'bar', 'baz' => null]);
         $this->assertEquals('bar', $cookies->get('foo'));
+        $this->assertNull($cookies->get('baz', 'defaultValue'));
         $this->assertNull($cookies->get('missing'));
         $this->assertEquals('defaultValue', $cookies->get('missing', 'defaultValue'));
     }


### PR DESCRIPTION
Fixes #149 