### PR TITLE
Prohibited chars in reason phrase

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -213,6 +213,10 @@ class Response extends Message implements ResponseInterface
             throw new InvalidArgumentException('Response reason phrase must be a string.');
         }
 
+        if (strpos($reasonPhrase, '\r') || strpos($reasonPhrase, '\n')) {
+            throw new InvalidArgumentException('Reason phrase contains one of the following prohibited characters: \r \n');
+        }
+
         return $reasonPhrase;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -214,7 +214,9 @@ class Response extends Message implements ResponseInterface
         }
 
         if (strpos($reasonPhrase, "\r") || strpos($reasonPhrase, "\n")) {
-            throw new InvalidArgumentException('Reason phrase contains one of the following prohibited characters: \r \n');
+            throw new InvalidArgumentException(
+                'Reason phrase contains one of the following prohibited characters: \r \n'
+            );
         }
 
         return $reasonPhrase;

--- a/src/Response.php
+++ b/src/Response.php
@@ -213,7 +213,7 @@ class Response extends Message implements ResponseInterface
             throw new InvalidArgumentException('Response reason phrase must be a string.');
         }
 
-        if (strpos($reasonPhrase, '\r') || strpos($reasonPhrase, '\n')) {
+        if (strpos($reasonPhrase, "\r") || strpos($reasonPhrase, "\n")) {
             throw new InvalidArgumentException('Reason phrase contains one of the following prohibited characters: \r \n');
         }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -124,6 +124,24 @@ class ResponseTest extends TestCase
         $this->assertEquals('', $responseWithNoMessage->getReasonPhrase());
     }
 
+    public function testResonPhraseContainsCarriageReturn()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Reason phrase contains one of the following prohibited characters: \r \n');
+
+        $response = new Response();
+        $response = $response->withStatus(404, "Not Found\r");
+    }
+
+    public function testResonPhraseContainsLineFeed()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Reason phrase contains one of the following prohibited characters: \r \n');
+
+        $response = new Response();
+        $response = $response->withStatus(404, "Not Found\n");
+    }
+
     public function testWithStatusValidReasonPhraseObject()
     {
         $mock = $this->getMockBuilder('ResponseTestReasonPhrase')->setMethods(['__toString'])->getMock();


### PR DESCRIPTION
According to https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html reason phrase should exclude CR, LF chars