### PR TITLE
Add method returning client provided file path

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -208,6 +208,18 @@ class UploadedFile implements UploadedFileInterface
     {
         return $this->size;
     }
+    
+    /**
+     * Returns the client-provided full path to the file
+     *
+     * @internal This method is not part of the PSR-7 standard
+     *
+     * @return string
+     */
+    public function getFilePath(): string
+    {
+        return $this->file;
+    }
 
     /**
      * Create a normalized tree of UploadedFile instances from the Environment.

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -153,6 +153,7 @@ class UploadedFileTest extends TestCase
         $this->assertEquals($attr['type'], $uploadedFile->getClientMediaType());
         $this->assertEquals($attr['size'], $uploadedFile->getSize());
         $this->assertEquals($attr['error'], $uploadedFile->getError());
+        $this->assertEquals($attr['tmp_name'], $uploadedFile->getFilePath());
 
         return $uploadedFile;
     }
@@ -183,6 +184,7 @@ class UploadedFileTest extends TestCase
         $this->assertEquals($attr['type'], $uploadedFile->getClientMediaType());
         $this->assertEquals($attr['size'], $uploadedFile->getSize());
         $this->assertEquals($attr['error'], $uploadedFile->getError());
+        $this->assertEquals($attr['tmp_name'], $uploadedFile->getFilePath());
 
         return $uploadedFile;
     }
@@ -409,6 +411,7 @@ class UploadedFileTest extends TestCase
         $this->assertSame($error, $file->getError());
         $this->assertSame($clientFilename, $file->getClientFilename());
         $this->assertSame($clientMediaType, $file->getClientMediaType());
+        $this->assertSame($stream->getMetadata('uri'), $file->getFilePath());
     }
 
     /**


### PR DESCRIPTION
UploadedFile class has a property containing temporary path of the
uploaded file, which is inaccessible outside of the class. But there is
a need of accessing this property outside of the class, when for
example you must upload the uploaded file directly to the cloud(e.g.
Amazon S3 bucket) without saving it to your local file system. So a
getter method is created returning the value of this property.