### PR TITLE
Added `@return $this` in `Message::withXXX ` methods PHPDoc

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -70,6 +70,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
+     * @return $this;
      * {@inheritdoc}
      */
     public function withProtocolVersion($version)
@@ -121,6 +122,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
+     * @return $this;
      * {@inheritdoc}
      */
     public function withHeader($name, $value)
@@ -136,6 +138,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
+     * @return $this;
      * {@inheritdoc}
      */
     public function withAddedHeader($name, $value)
@@ -151,6 +154,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
+     * @return $this;
      * {@inheritdoc}
      */
     public function withoutHeader($name)
@@ -174,6 +178,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
+     * @return $this;
      * {@inheritdoc}
      */
     public function withBody(StreamInterface $body)

--- a/src/Message.php
+++ b/src/Message.php
@@ -70,7 +70,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @return $this;
+     * @return static
      * {@inheritdoc}
      */
     public function withProtocolVersion($version)
@@ -122,7 +122,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @return $this;
+     * @return static
      * {@inheritdoc}
      */
     public function withHeader($name, $value)
@@ -138,7 +138,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @return $this;
+     * @return static
      * {@inheritdoc}
      */
     public function withAddedHeader($name, $value)
@@ -154,7 +154,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @return $this;
+     * @return static
      * {@inheritdoc}
      */
     public function withoutHeader($name)
@@ -178,7 +178,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * @return $this;
+     * @return static
      * {@inheritdoc}
      */
     public function withBody(StreamInterface $body)


### PR DESCRIPTION
Added `@return $this` in `Message::withXXX ` methods PHPDoc to allow for correct return type inheritance (in terms of IDE lookup systems).

This is in accordance with the [phpDocumentor documentation on Inhertance](https://docs.phpdoc.org/latest/guides/inheritance.html).

It fixes #146 

I'm available if anything needs to be done to get this accepted. 

Cheers