### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,12 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "fig/http-message-util": "^1.1.4",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
-    "ralouphie/getallheaders": "^3"
+    "ralouphie/getallheaders": "^3",
+    "symfony/polyfill-php80": "^1.18"
   },
   "require-dev": {
     "ext-json": "*",
@@ -40,8 +41,9 @@
     "http-interop/http-factory-tests": "^0.7.0",
     "php-http/psr7-integration-tests": "dev-master",
     "phpstan/phpstan": "^0.12",
-    "phpunit/phpunit": "^8.5",
-    "squizlabs/php_codesniffer": "^3.5"
+    "phpunit/phpunit": "^8.5 || ^9.3",
+    "squizlabs/php_codesniffer": "^3.5",
+    "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
   },
   "provide": {
     "psr/http-message-implementation": "1.0",

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -66,7 +66,16 @@ class StreamFactory implements StreamFactoryInterface
             ));
         });
 
-        $resource = fopen($filename, $mode);
+        try {
+            $resource = fopen($filename, $mode);
+        } catch (\ValueError $exception) {
+            throw new RuntimeException(sprintf(
+                'Unable to open %s using mode %s: %s',
+                $filename,
+                $mode,
+                $exception->getMessage()
+            ));
+        }
         restore_error_handler();
 
         if ($exc) {

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -53,29 +53,35 @@ class StreamFactory implements StreamFactoryInterface
         string $mode = 'r',
         StreamInterface $cache = null
     ): StreamInterface {
-        // When fopen fails, PHP normally raises a warning. Add an error
+        // When fopen fails, PHP 7 normally raises a warning. Add an error
         // handler to check for errors and throw an exception instead.
+        // On PHP 8, exceptions are thrown.
         $exc = null;
 
-        set_error_handler(function (int $errno, string $errstr) use ($filename, $mode, &$exc) {
+        // Would not be initialized if fopen throws on PHP >= 8.0
+        $resource = null;
+
+        $errorHandler = function (string $errorMessage) use ($filename, $mode, &$exc) {
             $exc = new RuntimeException(sprintf(
                 'Unable to open %s using mode %s: %s',
                 $filename,
                 $mode,
-                $errstr
+                $errorMessage
             ));
+        };
+
+        set_error_handler(function (int $errno, string $errstr) use ($errorHandler) {
+            $errorHandler($errstr);
         });
 
         try {
             $resource = fopen($filename, $mode);
+        // @codeCoverageIgnoreStart
+        // (Can only be executed in PHP >= 8.0)
         } catch (\ValueError $exception) {
-            throw new RuntimeException(sprintf(
-                'Unable to open %s using mode %s: %s',
-                $filename,
-                $mode,
-                $exception->getMessage()
-            ));
+            $errorHandler($exception->getMessage());
         }
+        // @codeCoverageIgnoreEnd
         restore_error_handler();
 
         if ($exc) {

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Slim\Psr7\Stream;
+use ValueError;
 
 use function fopen;
 use function fwrite;
@@ -78,7 +79,7 @@ class StreamFactory implements StreamFactoryInterface
             $resource = fopen($filename, $mode);
         // @codeCoverageIgnoreStart
         // (Can only be executed in PHP >= 8.0)
-        } catch (\ValueError $exception) {
+        } catch (ValueError $exception) {
             $errorHandler($exception->getMessage());
         }
         // @codeCoverageIgnoreEnd

--- a/tests/Factory/UploadedFileFactoryTest.php
+++ b/tests/Factory/UploadedFileFactoryTest.php
@@ -12,6 +12,7 @@ namespace Slim\Tests\Psr7\Factory;
 
 use Interop\Http\Factory\UploadedFileFactoryTestCase;
 use InvalidArgumentException;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Factory\UploadedFileFactory;
@@ -24,6 +25,8 @@ use function tempnam;
 
 class UploadedFileFactoryTest extends UploadedFileFactoryTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @return UploadedFileFactory
      */

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Slim\Tests\Psr7;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -24,6 +25,8 @@ use function trim;
 
 class StreamTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var resource pipe stream file handle
      */

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -12,6 +12,7 @@ namespace Slim\Tests\Psr7;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use ReflectionProperty;
@@ -42,6 +43,8 @@ use const UPLOAD_ERR_OK;
 
 class UploadedFileTest extends TestCase
 {
+    use ProphecyTrait;
+
     private static $filename = './phpUxcOty';
 
     private static $tmpFiles = ['./phpUxcOty'];
@@ -245,7 +248,7 @@ class UploadedFileTest extends TestCase
     public function testMoveToRenameFailure()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('/^Error moving uploaded file .* to .*$/');
+        $this->expectExceptionMessageMatches('/^Error moving uploaded file .* to .*$/');
 
         $uploadedFile = $this->generateNewTmpFile();
 
@@ -280,7 +283,7 @@ class UploadedFileTest extends TestCase
     public function testMoveToSapiMoveUploadedFileFails(UploadedFile $uploadedFile)
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~Error moving uploaded file.*~');
+        $this->expectExceptionMessageMatches('~Error moving uploaded file.*~');
 
         $GLOBALS['is_uploaded_file_return'] = true;
 


### PR DESCRIPTION
Hi! I'm interested in contributing to make Slim 4 compatible with PHP 8. [I've written some](https://github.com/slimphp/Slim/issues/2977#issuecomment-703194522) for the `Slim` core repo but a big part of this is about dependencies, so I figured I'd start from the "subcomponents" like this one.

~~**Blockers:**~~ all set!
* [x] https://github.com/php-fig/http-message-util/pull/19

As I'm new to open-source contributions and I've touched a lot of points that are not purely technical but have a significant 'policy/social' side, I'd like to know if the decisions I've taken so far are aligned with the views of the Slim maintainers — mostly regarding dependencies and test warnings.

**Coverage:** is it OK to use coverage ignore annotations for the catch-block that only gets executed in PHP 8? I can't figure out a way to solve this because different code paths will be executed in PHP 7/8 and I see no way to annotate this specifically for coverage analysis.

**About new dependencies:** I don't know if I've reached a good balance in the "minimizing dependencies" vs. "not reinventing the wheel" tradeoff. I upgraded one dependency and pulled two new ones:

- It was necessary to polyfill \ValueError to pass the PHPStan checks. I did this with `symfony/polyfill-php80`. Is this ok?
- I was having some trouble with PHPUnit 9 deprecating Prophecy from its core until I found a ready solution for that: [weirdan/prophecy-shim][]. Is it OK to pull this dependency (dev-only)?

**Test suite warnings:** [php-http/psr7-integration-tests][] uses assertions (`assertRegExp` and `assertFileNotExists`) deprecated in PHPUnit 9.1 but unavailable on PHPUnit 8 (still required for PHP 7.2 support). Do we need to fix that or is it acceptable to leave these warnings for now (11 warnings)? Of course I would prefer to remove the warnings, but this depends on other projects — if this is important, I'll see what I can do there too.

[fig/http-message-util]: https://github.com/php-fig/http-message-util/pull/19
[php-http/psr7-integration-tests]: https://github.com/php-http/psr7-integration-tests/
[weirdan/prophecy-shim]: https://github.com/weirdan/prophecy-shim/
