### PR TITLE
Draft: Fix moving uploaded file crashed when source was stream

### DIFF
--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -240,6 +240,21 @@ class UploadedFileTest extends TestCase
         return $uploadedFile;
     }
 
+    public function testMoveToWhenUploadFileInitializedFromStream()
+    {
+        $uploadedFile = new UploadedFile(
+            (new StreamFactory())->createStream('12345678')
+        );
+
+        $tempName = uniqid('file-');
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $tempName;
+        $uploadedFile->moveTo($path);
+
+        $this->assertFileExists($path);
+
+        unlink($path);
+    }
+
     /**
      */
     public function testMoveToRenameFailure()


### PR DESCRIPTION
**Description** 

When UploadedFile is created from stream then calling `movingTo` will throw an exception.

**Script to reproduce the bug**
```
require_once __DIR__ . '/vendor/autoload.php';

$file = new \Slim\Psr7\UploadedFile(
    (new \Slim\Psr7\Factory\StreamFactory())->createStream('Hello, World!')
);

$targetPath = tempnam(sys_get_temp_dir(), 'sample');
$file->moveTo($targetPath);

echo file_get_contents($targetPath);

```

Expected output:

`Hello, World!`

Actual output:

```
PHP Warning:  rename(): PHP wrapper does not support renaming in /home/rait/dev/github/Slim-Psr7/src/UploadedFile.php on line 172
PHP Stack trace:
PHP   1. {main}() /home/rait/dev/github/Slim-Psr7/demo.php:0
PHP   2. Slim\Psr7\UploadedFile->moveTo() /home/rait/dev/github/Slim-Psr7/demo.php:10
PHP   3. rename() /home/rait/dev/github/Slim-Psr7/src/UploadedFile.php:172
PHP Fatal error:  Uncaught RuntimeException: Error moving uploaded file  to /tmp/samplezHN38z in /home/rait/dev/github/Slim-Psr7/src/UploadedFile.php:173
Stack trace:
#0 /home/rait/dev/github/Slim-Psr7/demo.php(10): Slim\Psr7\UploadedFile->moveTo('/tmp/samplezHN3...')
#1 {main}
  thrown in /home/rait/dev/github/Slim-Psr7/src/UploadedFile.php on line 173
```

**Motivation**

I discovered this bug when I was creating a stub for a test.

**Notes on implementation**

I used `stream_copy_to_stream` for copying. I speculate that built-in stream function should be more efficient because it is implemented in C. 

My fix also handles `php://temp` case where huge files might be the case.