### PR TITLE
Fixed PHPUnit warning for deprecated method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,15 +33,15 @@
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
     "ralouphie/getallheaders": "^3",
-    "symfony/polyfill-php80": "^1.20"
+    "symfony/polyfill-php80": "^1.22"
   },
   "require-dev": {
     "ext-json": "*",
     "adriansuter/php-autoload-override": "^1.2",
-    "http-interop/http-factory-tests": "^0.8.0",
+    "http-interop/http-factory-tests": "^0.9.0",
     "php-http/psr7-integration-tests": "dev-master",
     "phpstan/phpstan": "^0.12",
-    "phpunit/phpunit": "^8.5 || ^9.3",
+    "phpunit/phpunit": "^8.5 || ^9.5",
     "squizlabs/php_codesniffer": "^3.5",
     "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
   },

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -73,6 +73,7 @@ class StreamFactory implements StreamFactoryInterface
 
         set_error_handler(function (int $errno, string $errstr) use ($errorHandler) {
             $errorHandler($errstr);
+            return true;
         });
 
         try {

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -12,6 +12,7 @@ namespace Slim\Tests\Psr7;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -36,6 +37,7 @@ use function strlen;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
+use function version_compare;
 
 use const DIRECTORY_SEPARATOR;
 use const UPLOAD_ERR_CANT_WRITE;
@@ -358,7 +360,11 @@ class UploadedFileTest extends TestCase
         $movedFileContents = ob_get_clean();
 
         $this->assertEquals($contents, $movedFileContents);
-        $this->assertFileNotExists($fileName);
+        if (version_compare(Version::series(), '9.1', '>=')) {
+            $this->assertFileDoesNotExist($fileName);
+        } else {
+            $this->assertFileNotExists($fileName);
+        }
     }
 
     /**


### PR DESCRIPTION
Only name changed. We can check PHPUnit version before calling this method. This check should be removed when Slim-Psr7 package drop PHP 7.2 support.

One test still fail as mentionned in #184.