### PR TITLE
Added None to the allowed SameSite parameters in toHeader method.

### DIFF
--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -170,7 +170,7 @@ class Cookies
             $result .= '; HttpOnly';
         }
 
-        if (isset($properties['samesite']) && in_array(strtolower($properties['samesite']), ['lax', 'strict'], true)) {
+        if (isset($properties['samesite']) && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case
             $result .= '; SameSite=' . $properties['samesite'];
         }

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -275,4 +275,11 @@ class CookiesTest extends TestCase
 
         Cookies::parseHeader(new stdClass());
     }
+
+    public function testSetSameSiteNoneToHeaders()
+    {
+        $cookies = new Cookies();
+        $cookies->set('foo', ['value' => 'bar', 'samesite' => 'None']);
+        $this->assertEquals('foo=bar; SameSite=None', $cookies->toHeaders()[0]);
+    }
 }


### PR DESCRIPTION
Added None to the allowed SameSite parameters in toHeader method because if you set it to samesite=None, it does not show because it is not included in the defined list while generating the header. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none