### PR TITLE
Fix test Uri with multiple slashes

### DIFF
--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -170,7 +170,10 @@ class Cookies
             $result .= '; HttpOnly';
         }
 
-        if (isset($properties['samesite']) && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)) {
+        if (
+            isset($properties['samesite'])
+            && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)
+        ) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case
             $result .= '; SameSite=' . $properties['samesite'];
         }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -484,7 +484,20 @@ class Uri implements UriInterface
         $query = $this->getQuery();
         $fragment = $this->getFragment();
 
-        $path = '/' . ltrim($path, '/');
+        if ($path !== '') {
+            if ($path[0] !== '/') {
+                if ($authority !== '') {
+                    // If the path is rootless and an authority is present, the path MUST be prefixed by "/".
+                    $path = '/' . $path;
+                }
+            } elseif (isset($path[1]) && $path[1] === '/') {
+                if ($authority === '') {
+                    // If the path is starting with more than one "/" and no authority is present,
+                    // the starting slashes MUST be reduced to one.
+                    $path = '/' . ltrim($path, '/');
+                }
+            }
+        }
 
         return ($scheme !== '' ? $scheme . ':' : '')
             . ($authority !== '' ? '//' . $authority : '')


### PR DESCRIPTION
String construction of `$path` was not respecting [PSR-7](https://www.php-fig.org/psr/psr-7/).

> The path can be concatenated without delimiters. But there are two cases where the path has to be adjusted to make the URI reference valid as PHP does not allow to throw an exception in __toString():
>     - **If the path is rootless and an authority is present, the path MUST be prefixed by "/".**
>     - **If the path is starting with more than one "/" and no authority is present, the starting slashes MUST be reduced to one.**

Fix #202 

(This PR also fix one PHPCS warning from `Cookies` class)