### PR TITLE
Drop Support for PHP 7.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1]
         experimental: [false]
         include:
           - php: 8.1

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "fig/http-message-util": "^1.1.5",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -31,24 +31,18 @@ class Cookies
 {
     /**
      * Cookies from HTTP request
-     *
-     * @var array
      */
-    protected $requestCookies = [];
+    protected array $requestCookies = [];
 
     /**
      * Cookies for HTTP response
-     *
-     * @var array
      */
-    protected $responseCookies = [];
+    protected array $responseCookies = [];
 
     /**
      * Default cookie properties
-     *
-     * @var array
      */
-    protected $defaults = [
+    protected array $defaults = [
         'value' => '',
         'domain' => null,
         'hostonly' => null,

--- a/src/Message.php
+++ b/src/Message.php
@@ -23,15 +23,9 @@ use function sprintf;
 
 abstract class Message implements MessageInterface
 {
-    /**
-     * @var string
-     */
-    protected $protocolVersion = '1.1';
+    protected string $protocolVersion = '1.1';
 
-    /**
-     * @var array
-     */
-    protected static $validProtocolVersions = [
+    protected static array $validProtocolVersions = [
         '1.0' => true,
         '1.1' => true,
         '2.0' => true,

--- a/src/Response.php
+++ b/src/Response.php
@@ -24,20 +24,11 @@ use function method_exists;
 
 class Response extends Message implements ResponseInterface
 {
-    /**
-     * @var int
-     */
-    protected $status = StatusCodeInterface::STATUS_OK;
+    protected int $status = StatusCodeInterface::STATUS_OK;
 
-    /**
-     * @var string
-     */
-    protected $reasonPhrase = '';
+    protected string $reasonPhrase = '';
 
-    /**
-     * @var array
-     */
-    protected static $messages = [
+    protected static array $messages = [
         // Informational 1xx
         StatusCodeInterface::STATUS_CONTINUE => 'Continue',
         StatusCodeInterface::STATUS_SWITCHING_PROTOCOLS => 'Switching Protocols',

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -78,10 +78,7 @@ class Stream implements StreamInterface
      */
     protected $isPipe;
 
-    /**
-     * @var bool
-     */
-    protected $finished = false;
+    protected bool $finished = false;
 
     /**
      * @var StreamInterface | null

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -60,17 +60,13 @@ class UploadedFile implements UploadedFileInterface
 
     /**
      * A valid PHP UPLOAD_ERR_xxx code for the file upload.
-     *
-     * @var int
      */
-    protected $error = UPLOAD_ERR_OK;
+    protected int $error = UPLOAD_ERR_OK;
 
     /**
      * Indicates if the upload is from a SAPI environment.
-     *
-     * @var bool
      */
-    protected $sapi = false;
+    protected bool $sapi = false;
 
     /**
      * @var StreamInterface|null
@@ -79,10 +75,8 @@ class UploadedFile implements UploadedFileInterface
 
     /**
      * Indicates if the uploaded file has already been moved.
-     *
-     * @var bool
      */
-    protected $moved = false;
+    protected bool $moved = false;
 
     /**
      * @param string|StreamInterface $fileNameOrStream The full path to the uploaded file provided by the client,

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -38,49 +38,31 @@ class Uri implements UriInterface
 
     /**
      * Uri scheme (without "://" suffix)
-     *
-     * @var string
      */
-    protected $scheme = '';
+    protected string $scheme = '';
 
-    /**
-     * @var string
-     */
-    protected $user = '';
+    protected string $user = '';
 
-    /**
-     * @var string
-     */
-    protected $password = '';
+    protected string $password = '';
 
-    /**
-     * @var string
-     */
-    protected $host = '';
+    protected string $host = '';
 
     /**
      * @var null|int
      */
     protected $port;
 
-    /**
-     * @var string
-     */
-    protected $path = '';
+    protected string $path = '';
 
     /**
      * Uri query string (without "?" prefix)
-     *
-     * @var string
      */
-    protected $query = '';
+    protected string $query = '';
 
     /**
      * Uri fragment string (without "#" prefix)
-     *
-     * @var string
      */
-    protected $fragment = '';
+    protected string $fragment = '';
 
     /**
      * @param string $scheme   Uri scheme.

--- a/tests/Assets/HeaderStack.php
+++ b/tests/Assets/HeaderStack.php
@@ -31,10 +31,7 @@ use function strpos;
 
 class HeaderStack
 {
-    /**
-     * @var string[][]
-     */
-    private static $data = [];
+    private static array $data = [];
 
     /**
      * Reset state

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -32,10 +32,7 @@ use function substr;
 class BodyTest extends TestCase
 {
     // @codingStandardsIgnoreStart
-    /**
-     * @var string
-     */
-    protected $text = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+    protected string $text = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
     // @codingStandardsIgnoreEnd
 
     /**

--- a/tests/Mocks/MessageStub.php
+++ b/tests/Mocks/MessageStub.php
@@ -18,10 +18,8 @@ class MessageStub extends Message
 {
     /**
      * Protocol version
-     *
-     * @var string
      */
-    public $protocolVersion;
+    public string $protocolVersion;
 
     /**
      * Headers

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -47,9 +47,9 @@ class UploadedFileTest extends TestCase
 {
     use ProphecyTrait;
 
-    private static $filename = './phpUxcOty';
+    private static string $filename = './phpUxcOty';
 
-    private static $tmpFiles = ['./phpUxcOty'];
+    private static array $tmpFiles = ['./phpUxcOty'];
 
     public static function setUpBeforeClass(): void
     {


### PR DESCRIPTION
This PR drops support for PHP 7.3 since [it reached its end of life and is no longer supported](https://www.php.net/eol.php).