### PR TITLE
Avoid falsy comparison

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -204,7 +204,7 @@ class Response extends Message implements ResponseInterface
             throw new InvalidArgumentException('Response reason phrase must be a string.');
         }
 
-        if (strpos($reasonPhrase, "\r") || strpos($reasonPhrase, "\n")) {
+        if (strpos($reasonPhrase, "\r") !== false || strpos($reasonPhrase, "\n") !== false) {
             throw new InvalidArgumentException(
                 'Reason phrase contains one of the following prohibited characters: \r \n'
             );


### PR DESCRIPTION
This PR fixes the comparison of the return value of [`strpos`](https://www.php.net/manual/en/function.strpos.php) function. 

If the needle string we are searching for is at the beginning of the haystack string, it will return 0 which is a valid offset and is **falsy**.

If you want to see a failing test, change [this line](https://github.com/slimphp/Slim-Psr7/blob/master/tests/ResponseTest.php#L142) like so:

```diff
- $response = $response->withStatus(404, "Not Found\n");
+ $response = $response->withStatus(404, "\nNot Found");
```