### PR TITLE
Replace `assertFileNotExists()` method

### DIFF
--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -190,7 +190,7 @@ class RequestTest extends TestCase
         // When `$preserveHost` is set to `true`, this method interacts with
         // the Host header in the following ways:
 
-        // - If the the Host header is missing or empty, and the new URI contains
+        // - If the Host header is missing or empty, and the new URI contains
         //   a host component, this method MUST update the Host header in the returned
         //   request.
         $uri1 = (new UriFactory())->createUri('');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -121,7 +121,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('', $responseWithNoMessage->getReasonPhrase());
     }
 
-    public function testResonPhraseContainsCarriageReturn()
+    public function testReasonPhraseContainsCarriageReturn()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Reason phrase contains one of the following prohibited characters: \r \n');
@@ -130,7 +130,7 @@ class ResponseTest extends TestCase
         $response = $response->withStatus(404, "Not Found\r");
     }
 
-    public function testResonPhraseContainsLineFeed()
+    public function testReasonPhraseContainsLineFeed()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Reason phrase contains one of the following prohibited characters: \r \n');

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -12,7 +12,6 @@ namespace Slim\Tests\Psr7;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\Version;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -349,11 +348,7 @@ class UploadedFileTest extends TestCase
         $movedFileContents = ob_get_clean();
 
         $this->assertEquals($contents, $movedFileContents);
-        if (version_compare(Version::series(), '9.1', '>=')) {
-            $this->assertFileDoesNotExist($fileName);
-        } else {
-            $this->assertFileNotExists($fileName);
-        }
+        $this->assertFileDoesNotExist($fileName);
     }
 
     public function testMoveToStreamCopyFailure()


### PR DESCRIPTION
This PR replaces `assertFileNotExists()` with `assertFileDoesNotExist()` since [it is deprecated](https://github.com/sebastianbergmann/phpunit/issues/4077) and will be removed in PHPUnit 10.