### PR TITLE
Explicitly specify with phpdoc return types from interface

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -124,6 +124,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withMethod($method)
     {
@@ -189,6 +190,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withRequestTarget($requestTarget)
     {
@@ -214,6 +216,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
@@ -243,6 +246,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withCookieParams(array $cookies)
     {
@@ -273,6 +277,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withQueryParams(array $query)
     {
@@ -292,6 +297,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withUploadedFiles(array $uploadedFiles)
     {
@@ -319,6 +325,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function getAttribute($name, $default = null)
     {
@@ -327,6 +334,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withAttribute($name, $value)
     {
@@ -338,6 +346,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withoutAttribute($name)
     {
@@ -358,6 +367,7 @@ class Request extends Message implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withParsedBody($data)
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -138,6 +138,7 @@ class Response extends Message implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withStatus($code, $reasonPhrase = '')
     {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -82,6 +82,7 @@ class Stream implements StreamInterface
 
     /**
      * {@inheritdoc}
+     * @return array|mixed
      */
     public function getMetadata($key = null)
     {
@@ -322,6 +323,7 @@ class Stream implements StreamInterface
 
     /**
      * {@inheritdoc}
+     * @return int
      */
     public function write($string)
     {

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -109,6 +109,7 @@ class UploadedFile implements UploadedFileInterface
 
     /**
      * {@inheritdoc}
+     * @return StreamInterface
      */
     public function getStream()
     {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -101,6 +101,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withScheme($scheme)
     {
@@ -165,6 +166,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withUserInfo($user, $password = null)
     {
@@ -216,6 +218,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withHost($host)
     {
@@ -264,6 +267,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withPort($port)
     {
@@ -312,6 +316,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withPath($path)
     {
@@ -360,6 +365,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withQuery($query)
     {
@@ -410,6 +416,7 @@ class Uri implements UriInterface
 
     /**
      * {@inheritdoc}
+     * @return static
      */
     public function withFragment($fragment)
     {


### PR DESCRIPTION
It allows avoiding deprecation messages from `symfony/error-handler` like a 
```
[info] User Deprecated: Method "Psr\Http\Message\ServerRequestInterface::withParsedBody()" might add "static" as a native return type declaration in the future. Do the same in implementation "Slim\Psr7\Request" now to avoid errors or add an explicit @return annotation to suppress this message.
```

Fixed via `symfony/error-handler` patch script: ` SYMFONY_PATCH_TYPE_DECLARATIONS="force=phpdoc&php=7.4" ./vendor/bin/patch-type-declarations`

Some details about why this is necessary and how checks with trigger deprecations work: https://wouterj.nl/2021/09/symfony-6-native-typing