### PR TITLE
Remove dependency on ralouphie/getallheaders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "fig/http-message-util": "^1.1.5",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
-    "ralouphie/getallheaders": "^3.0",
     "symfony/polyfill-php80": "^1.27"
   },
   "require-dev": {


### PR DESCRIPTION
This was added in https://github.com/slimphp/Slim-Psr7/pull/76
Then moved as a normal dependency in https://github.com/slimphp/Slim-Psr7/pull/111 for https://github.com/slimphp/Slim-Psr7/issues/101

And got upgraded in https://github.com/slimphp/Slim-Psr7/pull/112

I see no reason this function would be now missing in PHP 7.4+