### PR TITLE
Drop support for PHP 7.4 & fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
         php: [8.0, 8.1, 8.2]
         experimental: [false]
         include:
-          - php: 8.1
+          - php: 8.2
             analysis: true
 
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Set up PHP ${{ matrix.php }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
         experimental: [false]
         include:
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1]
         experimental: [false]
         include:
           - php: 8.1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ composer require slim/psr7
 
 This will install the `slim/psr7` component and all required dependencies.
 
-PHP 7.4 or newer is required.
+PHP 8.0 or newer is required.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.0",
     "fig/http-message-util": "^1.1.5",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -346,9 +346,7 @@ class Uri implements UriInterface
     {
         $match = preg_replace_callback(
             '/(?:[^a-zA-Z0-9_\-\.~:@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/',
-            function ($match) {
-                return rawurlencode($match[0]);
-            },
+            fn (array $match) => rawurlencode($match[0]),
             $path
         );
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -311,6 +311,11 @@ class Uri implements UriInterface
      */
     public function getPath(): string
     {
+        if (str_starts_with($this->path, '/')) {
+            // Use only one leading slash to prevent XSS attempts.
+            return '/' . ltrim($this->path, '/');
+        }
+
         return $this->path;
     }
 
@@ -464,7 +469,7 @@ class Uri implements UriInterface
     {
         $scheme = $this->getScheme();
         $authority = $this->getAuthority();
-        $path = $this->getPath();
+        $path = $this->path;
         $query = $this->getQuery();
         $fragment = $this->getFragment();
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -23,6 +23,7 @@ use function method_exists;
 use function preg_replace_callback;
 use function rawurlencode;
 use function str_replace;
+use function str_starts_with;
 use function strtolower;
 
 use const FILTER_FLAG_IPV6;


### PR DESCRIPTION
This PR;

- drops support for PHP 7.4 since [it reached its end of life and is no longer supported](https://www.php.net/eol.php),
- allows tests to run on PHP 8.2,
- fixes tests (by ensuring only one leading slash is present in a path, which was introduced in https://github.com/php-http/psr7-integration-tests/pull/54),
- closes #275.