### PR TITLE
Improve `Header` by using PHP native types 🐘

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -10,10 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Psr7;
 
-use InvalidArgumentException;
-
 use function array_merge;
-use function is_array;
 use function is_string;
 
 class Header
@@ -75,10 +72,6 @@ class Header
     {
         if (is_string($values)) {
             return $this->addValue($values);
-        }
-
-        if (!is_array($values)) {
-            throw new InvalidArgumentException('Parameter 1 of Header::addValues() should be a string or an array.');
         }
 
         $this->values = array_merge($this->values, $values);

--- a/src/Header.php
+++ b/src/Header.php
@@ -71,7 +71,7 @@ class Header
      *
      * @return self
      */
-    public function addValues($values): self
+    public function addValues(array|string $values): self
     {
         if (is_string($values)) {
             return $this->addValue($values);

--- a/src/Request.php
+++ b/src/Request.php
@@ -31,10 +31,7 @@ use function str_replace;
 
 class Request extends Message implements ServerRequestInterface
 {
-    /**
-     * @var string
-     */
-    protected $method;
+    protected string $method;
 
     /**
      * @var UriInterface

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -29,19 +29,19 @@ class HeaderTest extends TestCase
         return new Header($originalName, $normalizedName, $values);
     }
 
-    public function testGetOriginalName()
+    public function testGetOriginalName(): void
     {
         $header = $this->headerFactory();
         $this->assertEquals('ACCEPT', $header->getOriginalName());
     }
 
-    public function testGetNormalizedName()
+    public function testGetNormalizedName(): void
     {
         $header = $this->headerFactory();
         $this->assertEquals('accept', $header->getNormalizedName());
     }
 
-    public function testAddValue()
+    public function testAddValue(): void
     {
         $header = $this->headerFactory();
         $header2 = $header->addValue('text/html');
@@ -50,7 +50,7 @@ class HeaderTest extends TestCase
         $this->assertSame($header2, $header);
     }
 
-    public function testAddValuesString()
+    public function testAddValuesString(): void
     {
         $header = $this->headerFactory();
         $header2 = $header->addValues('text/html');

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Psr7;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Header;
 
@@ -58,14 +57,5 @@ class HeaderTest extends TestCase
 
         $this->assertEquals(['application/json', 'text/html'], $header->getValues());
         $this->assertSame($header2, $header);
-    }
-
-    public function testAddValuesNull()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Parameter 1 of Header::addValues() should be a string or an array.');
-
-        $header = $this->headerFactory();
-        $header->addValues(null);
     }
 }


### PR DESCRIPTION
This PR declares PHP native type for the parameter  `$values` of the [`Header::addValues`](https://github.com/slimphp/Slim-Psr7/blob/master/src/Header.php#L74) method and removes related test method. This way, we no longer need to manually check if the value is string or array.