### PR TITLE
update for new compatibility tests

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -199,7 +199,7 @@ class Uri implements UriInterface
         }
 
         $match =  preg_replace_callback(
-            '/(?:[^a-zA-Z0-9_\-\.~!\$&\'\(\)\*\+,;=]+|%(?![A-Fa-f0-9]{2}))/u',
+            '/(?:[^%a-zA-Z0-9_\-\.~\pL!\$&\'\(\)\*\+,;=]+|%(?![A-Fa-f0-9]{2}))/u',
             function ($match) {
                 return rawurlencode($match[0]);
             },

--- a/tests/Integration/UploadedFileTest.php
+++ b/tests/Integration/UploadedFileTest.php
@@ -21,13 +21,31 @@ class UploadedFileTest extends UploadedFileIntegrationTest
 {
     use BaseTestFactories;
 
+    protected string $tempFilename;
+
     /**
      * @return UploadedFileInterface
      */
     public function createSubject()
     {
-        $file = tempnam(sys_get_temp_dir(), 'Slim_Http_UploadedFileTest_');
+        $this->tempFilename = tempnam(sys_get_temp_dir(), 'Slim_Http_UploadedFileTest_');
+        if (!$this->tempFilename) {
+            throw new \RuntimeException("Unable to create temporary file");
+        }
+        file_put_contents($this->tempFilename, '12345');
 
-        return new UploadedFile($file);
+        return new UploadedFile(
+            $this->tempFilename,
+            basename($this->tempFilename),
+            'text/plain',
+            (int)filesize($this->tempFilename)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->tempFilename)) {
+            unlink($this->tempFilename);
+        }
     }
 }


### PR DESCRIPTION
- Don't double encode when filtering userinfo
- Return a true UploadedFile for the integration test

This allows us to pass the latest per7-integration-tests and will require a release to a new minor version.