### PR TITLE
Fix CVE-2023-30536 - GHSA-q2qj-628g-vhfw (1.4.x)

### DIFF
--- a/src/Headers.php
+++ b/src/Headers.php
@@ -269,7 +269,7 @@ class Headers implements HeadersInterface
      */
     protected function validateHeaderName($name): void
     {
-        if (!is_string($name) || preg_match("@^[!#$%&'*+.^_`|~0-9A-Za-z-]+$@", $name) !== 1) {
+        if (!is_string($name) || preg_match("@^[!#$%&'*+.^_`|~0-9A-Za-z-]+$@D", $name) !== 1) {
             throw new InvalidArgumentException('Header name must be an RFC 7230 compatible string.');
         }
     }
@@ -289,7 +289,7 @@ class Headers implements HeadersInterface
             );
         }
 
-        $pattern = "@^[ \t\x21-\x7E\x80-\xFF]*$@";
+        $pattern = "@^[ \t\x21-\x7E\x80-\xFF]*$@D";
         foreach ($items as $item) {
             $hasInvalidType = !is_numeric($item) && !is_string($item);
             $rejected = $hasInvalidType || preg_match($pattern, (string) $item) !== 1;


### PR DESCRIPTION
Security fix: Reject newlines at end of header names

(cherry picked from commit ed1d553225dd190875d8814c47460daed4b550bb)