### PR TITLE
Fix error handling in Stream::getContents()

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -404,7 +404,7 @@ class Stream implements StreamInterface
      *
      * return string The contents
      */
-    public function getStreamContents(): string
+    protected function getStreamContents(): string
     {
         $contents = false;
         $exception = null;


### PR DESCRIPTION
The current implementation of `stream_get_contents()` swallows errors, leading to issues like https://github.com/symfony/symfony/issues/52490, where errors reported by the stream layer aren't propagated to user-land.

This is even in the C source:
https://github.com/php/php-src/blob/311cae03e730c76aed343312319ed8cf1c37ade0/main/streams/streams.c#L1512

### Proposed Solution

To address the issue, @nicolas-grekas proposes replacing the usage of `stream_get_contents()` with `fread()`. This change will ensure that errors are not concealed, and they will be thrown as expected.

Using fread(), should fix this issue.

See here: https://github.com/Nyholm/psr7/pull/252

Thanks to @nicolas-grekas