### PR TITLE
Enable opt-out of URI scheme filtering

### DIFF
--- a/src/Factory/UriFactory.php
+++ b/src/Factory/UriFactory.php
@@ -27,6 +27,8 @@ use const PHP_URL_QUERY;
 
 class UriFactory implements UriFactoryInterface
 {
+    public const URI_CLASS = Uri::class;
+
     /**
      * {@inheritdoc}
      */
@@ -47,7 +49,7 @@ class UriFactory implements UriFactoryInterface
         $query = $parts['query'] ?? '';
         $fragment = $parts['fragment'] ?? '';
 
-        return new Uri($scheme, $host, $port, $path, $query, $fragment, $user, $pass);
+        return $this->makeUriObject($scheme, $host, $port, $path, $query, $fragment, $user, $pass);
     }
 
     /**
@@ -108,6 +110,19 @@ class UriFactory implements UriFactoryInterface
         }
 
         // Build Uri and return
-        return new Uri($scheme, $host, $port, $requestUri, $queryString, '', $username, $password);
+        return $this->makeUriObject($scheme, $host, $port, $requestUri, $queryString, '', $username, $password);
+    }
+
+    protected function makeUriObject(
+        string $scheme,
+        string $host,
+        ?int $port = null,
+        string $path = '/',
+        string $query = '',
+        string $fragment = '',
+        string $user = '',
+        string $password = ''
+    ): Uri {
+        return new (static::URI_CLASS)($scheme, $host, $port, $path, $query, $fragment, $user, $password);
     }
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -129,6 +129,11 @@ class Uri implements UriInterface
             throw new InvalidArgumentException('Uri scheme must be a string.');
         }
 
+        // In case the supported schemes list is null, do no filtering.
+        if (null === static::SUPPORTED_SCHEMES) {
+            return $scheme;
+        }
+
         $scheme = str_replace('://', '', strtolower($scheme));
         if (!key_exists($scheme, static::SUPPORTED_SCHEMES)) {
             throw new InvalidArgumentException(
@@ -286,6 +291,9 @@ class Uri implements UriInterface
      */
     protected function hasStandardPort(): bool
     {
+        if (!isset(static::SUPPORTED_SCHEMES[$this->scheme])) {
+            return null === $this->port;
+        }
         return static::SUPPORTED_SCHEMES[$this->scheme] === $this->port;
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -43,6 +43,14 @@ class UriTest extends TestCase
         $this->assertEquals('ws', $wsUri->getScheme());
     }
 
+    public function testSupportNoSchemeFilteringUsingInheritance()
+    {
+        $uri = new class ('whatever', 'example.com') extends Uri {
+            public const SUPPORTED_SCHEMES = null;
+        };
+        $this->assertEquals('whatever', $uri->getScheme());
+    }
+
     public function testGetScheme()
     {
         $this->assertEquals('https', $this->uriFactory()->getScheme());
@@ -168,6 +176,35 @@ class UriTest extends TestCase
 
         $this->assertNull($uriHttp->getPort());
         $this->assertNull($uriHttps->getPort());
+    }
+
+    public function testGetPortWithoutSchemeOrStandardPort()
+    {
+        $uri = new Uri('', 'www.example.com', 80);
+
+        $this->assertEquals(80, $uri->getPort());
+    }
+
+    public function testSupportNoSchemeWithStandardPort()
+    {
+        $uri = new class ('', 'example.com', 80) extends Uri {
+            public const SUPPORTED_SCHEMES = [
+                '' => 80,
+            ];
+        };
+
+        $this->assertNull($uri->getPort());
+    }
+
+    public function testSupportNoSchemeWithoutStandardPort()
+    {
+        $uri = new class ('', 'example.com', 1234) extends Uri {
+            public const SUPPORTED_SCHEMES = [
+                '' => 80,
+            ];
+        };
+
+        $this->assertEquals(1234, $uri->getPort());
     }
 
     public function testGetPortWithoutSchemeAndPort()


### PR DESCRIPTION
> addresses issue #282 

This PR makes it possible to opt-out of URI scheme filtering. This may be used for generic scenarios where the schemes are not know and it is not desirable to limit them.

The filtering is opted out in the `Uri` class by inheriting it and overriding the `Uri::SUPPORTED_SCHEMES` constant, setting it to `null`:
```php
class MyUri extends Uri {
    public const SUPPORTED_SCHEMES = null;
}
```
It is then possible to create URIs with any scheme:
```php
new MyUri('whatever', 'example.com');
new MyUri('ldap', 'ldap.example.com');
```

To use the new class with `UriFactory`, one has to, again, inherit it, having two options:
- either override the newly introduced `UriFactory::makeUriObject` method
- or override the newly introduced class constant `UriFactory::URI_CLASS`

```php
class MyUriFactory extends UriFactory
{
    public const URI_CLASS = MyUri::class;
}
```
or
```php
class MyUriFactory extends UriFactory
{
    protected function makeUriObject(
        string $scheme,
        string $host,
        ?int $port = null,
        string $path = '/',
        string $query = '',
        string $fragment = '',
        string $user = '',
        string $password = ''
    ): Uri {
        return new class($scheme, $host, $port, $path, $query, $fragment, $user, $password) extends Uri {
            public const SUPPORTED_SCHEMES = null;
        };
    }
}
```

---

Personally, I'm not happy with this inheritance-based approach, it seems to me that the filtering should be opt-in in and a function of the factory, not the Uri object. That would be breaking change. But even it the functionality was moved, the standard port omission would stop working in the Uri object.

I first tried using static variable, that could be manipulated globally, but that approach broke the existing inheritance due to restrictions in PHP. 
