### PR TITLE
Backports for 1.4.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         experimental: [false]
+        dependency-versions: ['locked']
         include:
+          - php: 7.2
+            experimental: false
+            dependency-versions: lowest
           - php: 8.0
             analysis: true
           - php: nightly
@@ -30,6 +34,8 @@ jobs:
 
       - name: Install dependencies with Composer
         uses: ramsey/composer-install@v1
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
 
       - name: Coding standards
         if: matrix.analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,18 @@ jobs:
         php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         experimental: [false]
         dependency-versions: ['locked']
+        coverage: [false]
         include:
           - php: 7.2
             experimental: false
             dependency-versions: lowest
+            coverage: false
           - php: 8.0
             analysis: true
+            coverage: false
           - php: nightly
             experimental: true
+            coverage: false
 
     steps:
       - name: Checkout
@@ -49,7 +53,7 @@ jobs:
         run: vendor/bin/phpunit --no-coverage
 
       - name: Upload coverage results to Coveralls
-        if: matrix.analysis
+        if: matrix.coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: vendor/bin/phpstan analyse src
 
       - name: Tests
-        run: vendor/bin/phpunit --coverage-clover clover.xml
+        run: vendor/bin/phpunit --no-coverage
 
       - name: Upload coverage results to Coveralls
         if: matrix.analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,17 +10,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         experimental: [false]
         include:
           - php: 8.0
             analysis: true
-          - php: 8.1
+          - php: nightly
             experimental: true
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "ext-json": "*",
     "adriansuter/php-autoload-override": "^1.2",
     "http-interop/http-factory-tests": "^0.9.0",
-    "php-http/psr7-integration-tests": "dev-master",
+    "php-http/psr7-integration-tests": "^1.3",
     "phpstan/phpstan": "^0.12",
     "phpunit/phpunit": "^8.5 || ^9.5",
     "squizlabs/php_codesniffer": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "http-interop/http-factory-tests": "^1.0 || ^2.0",
     "php-http/psr7-integration-tests": "^1.3",
     "phpstan/phpstan": "^0.12",
-    "phpunit/phpunit": "^8.5 || ^9.5",
+    "phpunit/phpunit": "^8.5 || ^9.5 || ^10",
     "squizlabs/php_codesniffer": "^3.6",
     "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   "require-dev": {
     "ext-json": "*",
     "adriansuter/php-autoload-override": "^1.2",
-    "http-interop/http-factory-tests": "^0.9.0",
+    "http-interop/http-factory-tests": "^1.0 || ^2.0",
     "php-http/psr7-integration-tests": "^1.3",
     "phpstan/phpstan": "^0.12",
     "phpunit/phpunit": "^8.5 || ^9.5",

--- a/src/Factory/StreamFactory.php
+++ b/src/Factory/StreamFactory.php
@@ -51,7 +51,7 @@ class StreamFactory implements StreamFactoryInterface
     public function createStreamFromFile(
         string $filename,
         string $mode = 'r',
-        StreamInterface $cache = null
+        ?StreamInterface $cache = null
     ): StreamInterface {
         set_error_handler(
             static function (int $errno, string $errstr) use ($filename, $mode): void {
@@ -82,7 +82,7 @@ class StreamFactory implements StreamFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createStreamFromResource($resource, StreamInterface $cache = null): StreamInterface
+    public function createStreamFromResource($resource, ?StreamInterface $cache = null): StreamInterface
     {
         if (!is_resource($resource)) {
             throw new InvalidArgumentException(

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -90,11 +90,11 @@ class Stream implements StreamInterface
 
     /**
      * @param  resource $stream  A PHP resource handle.
-     * @param  StreamInterface $cache A stream to cache $stream (useful for non-seekable streams)
+     * @param  StreamInterface|null $cache A stream to cache $stream (useful for non-seekable streams)
      *
      * @throws InvalidArgumentException If argument is not a resource.
      */
-    public function __construct($stream, StreamInterface $cache = null)
+    public function __construct($stream, ?StreamInterface $cache = null)
     {
         $this->attach($stream);
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -217,7 +217,7 @@ class Uri implements UriInterface
         }
 
         $match =  preg_replace_callback(
-            '/(?:[^a-zA-Z0-9_\-\.~!\$&\'\(\)\*\+,;=]+|%(?![A-Fa-f0-9]{2}))/u',
+            '/(?:[^%a-zA-Z0-9_\-\.~!\$&\'\(\)\*\+,;=]+|%(?![A-Fa-f0-9]{2}))/',
             function ($match) {
                 return rawurlencode($match[0]);
             },

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -328,7 +328,14 @@ class Uri implements UriInterface
      */
     public function getPath(): string
     {
-        return $this->path;
+        $path = $this->path;
+
+        // If the path starts with a / then remove all leading slashes except one.
+        if (strpos($path, '/') === 0) {
+            $path = '/' . ltrim($path, '/');
+        }
+
+        return $path;
     }
 
     /**
@@ -480,11 +487,13 @@ class Uri implements UriInterface
     {
         $scheme = $this->getScheme();
         $authority = $this->getAuthority();
-        $path = $this->getPath();
+        $path = $this->path;
         $query = $this->getQuery();
         $fragment = $this->getFragment();
 
-        $path = '/' . ltrim($path, '/');
+        if (! str_starts_with($path, '/')) {
+            $path = '/' . $path;
+        }
 
         return ($scheme !== '' ? $scheme . ':' : '')
             . ($authority !== '' ? '//' . $authority : '')

--- a/tests/Integration/StreamTest.php
+++ b/tests/Integration/StreamTest.php
@@ -28,7 +28,8 @@ class StreamTest extends StreamIntegrationTest
      * @var array with functionName => reason
      */
     protected $skippedTests = [
-        'testGetContentsError' => 'PHP 7.3 and 7.4 fail this test: stream_get_contents(): supplied resource is not a valid stream resource'
+        'testGetContentsError' => 'PHP 7.3 and 7.4 fail this test: stream_get_contents()'
+                                . ': supplied resource is not a valid stream resource'
     ];
 
     /**

--- a/tests/Integration/StreamTest.php
+++ b/tests/Integration/StreamTest.php
@@ -25,6 +25,13 @@ class StreamTest extends StreamIntegrationTest
     use BaseTestFactories;
 
     /**
+     * @var array with functionName => reason
+     */
+    protected $skippedTests = [
+        'testGetContentsError' => 'PHP 7.3 and 7.4 fail this test: stream_get_contents(): supplied resource is not a valid stream resource'
+    ];
+
+    /**
      * @param string|resource|StreamInterface $data
      *
      * @return StreamInterface

--- a/tests/Integration/UploadedFileTest.php
+++ b/tests/Integration/UploadedFileTest.php
@@ -22,6 +22,13 @@ class UploadedFileTest extends UploadedFileIntegrationTest
     use BaseTestFactories;
 
     /**
+     * @var array with functionName => reason
+     */
+    protected $skippedTests = [
+        'testGetSize' => 'PHP 7.2 fail this test: Failed asserting that \'\' matches PCRE pattern "|^[0-9]+$|"'
+    ];
+
+    /**
      * @return UploadedFileInterface
      */
     public function createSubject()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -21,6 +21,12 @@ use Slim\Psr7\Stream;
 use function fopen;
 use function property_exists;
 
+final class TestException implements \Stringable {
+    public function __toString(): string {
+        return 'Slim OK';
+    }
+}
+
 class ResponseTest extends TestCase
 {
     public function testConstructorWithDefaultArgs()
@@ -144,13 +150,7 @@ class ResponseTest extends TestCase
 
     public function testWithStatusValidReasonPhraseObject()
     {
-        $mock = $this->getMockBuilder('ResponseTestReasonPhrase')->setMethods(['__toString'])->getMock();
-        $mock->expects($this->once())
-            ->method('__toString')
-            ->will($this->returnValue('Slim OK'));
-
-        $response = new Response();
-        $response = $response->withStatus(200, $mock);
+        $response = $response->withStatus(200, new TestException());
         $this->assertEquals('Slim OK', $response->getReasonPhrase());
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -21,12 +21,6 @@ use Slim\Psr7\Stream;
 use function fopen;
 use function property_exists;
 
-final class TestException implements \Stringable {
-    public function __toString(): string {
-        return 'Slim OK';
-    }
-}
-
 class ResponseTest extends TestCase
 {
     public function testConstructorWithDefaultArgs()
@@ -150,7 +144,8 @@ class ResponseTest extends TestCase
 
     public function testWithStatusValidReasonPhraseObject()
     {
-        $response = $response->withStatus(200, new TestException());
+        $response = new Response();
+        $response = $response->withStatus(200, new StringableTestObject('Slim OK'));
         $this->assertEquals('Slim OK', $response->getReasonPhrase());
     }
 

--- a/tests/StringableTestObject.php
+++ b/tests/StringableTestObject.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Psr7/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Psr7;
+
+final class StringableTestObject implements \Stringable
+{
+    public function __construct(private string $value)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/StringableTestObject.php
+++ b/tests/StringableTestObject.php
@@ -12,8 +12,12 @@ namespace Slim\Tests\Psr7;
 
 final class StringableTestObject implements \Stringable
 {
-    public function __construct(private string $value)
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
     {
+        $this->value = $value;
     }
 
     public function __toString(): string

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -452,7 +452,7 @@ class UploadedFileTest extends TestCase
         new UploadedFile($stream);
     }
 
-    public function providerCreateFromGlobals()
+    public static function providerCreateFromGlobals()
     {
         return [
             // no nest: <input name="avatar" type="file">

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -15,6 +15,15 @@ use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Uri;
 use stdClass;
 
+final class TestObject implements \Stringable {
+
+    public function __construct(private readonly string $value) {}
+
+    public function __toString(): string {
+        return $this->value;
+    }
+}
+
 class UriTest extends TestCase
 {
     public function uriFactory()
@@ -125,10 +134,7 @@ class UriTest extends TestCase
 
     public function testWithHostValidObject()
     {
-        $mock = $this->getMockBuilder('UriTestHost')->setMethods(['__toString'])->getMock();
-        $mock->expects($this->once())
-            ->method('__toString')
-            ->will($this->returnValue('host.test'));
+        $mock = new TestObject('host.test');
 
         $uri = $this->uriFactory()->withHost($mock);
         $this->assertEquals('host.test', $uri->getHost());
@@ -291,10 +297,7 @@ class UriTest extends TestCase
 
     public function testWithQueryValidObject()
     {
-        $mock = $this->getMockBuilder('UriTestQuery')->setMethods(['__toString'])->getMock();
-        $mock->expects($this->once())
-            ->method('__toString')
-            ->will($this->returnValue('xyz=123'));
+        $mock = new TestObject('xyz=123');
 
         $uri = $this->uriFactory()->withQuery($mock);
         $this->assertEquals('xyz=123', $uri->getQuery());
@@ -345,10 +348,7 @@ class UriTest extends TestCase
 
     public function testWithFragmentValidObject()
     {
-        $mock = $this->getMockBuilder('UriTestFragment')->setMethods(['__toString'])->getMock();
-        $mock->expects($this->once())
-            ->method('__toString')
-            ->will($this->returnValue('other-fragment'));
+        $mock = new TestObject('other-fragment');
 
         $uri = $this->uriFactory()->withFragment($mock);
         $this->assertEquals('other-fragment', $uri->getFragment());

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -15,15 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Uri;
 use stdClass;
 
-final class TestObject implements \Stringable {
-
-    public function __construct(private readonly string $value) {}
-
-    public function __toString(): string {
-        return $this->value;
-    }
-}
-
 class UriTest extends TestCase
 {
     public function uriFactory()
@@ -134,7 +125,7 @@ class UriTest extends TestCase
 
     public function testWithHostValidObject()
     {
-        $mock = new TestObject('host.test');
+        $mock = new StringableTestObject('host.test');
 
         $uri = $this->uriFactory()->withHost($mock);
         $this->assertEquals('host.test', $uri->getHost());
@@ -297,7 +288,7 @@ class UriTest extends TestCase
 
     public function testWithQueryValidObject()
     {
-        $mock = new TestObject('xyz=123');
+        $mock = new StringableTestObject('xyz=123');
 
         $uri = $this->uriFactory()->withQuery($mock);
         $this->assertEquals('xyz=123', $uri->getQuery());
@@ -348,7 +339,7 @@ class UriTest extends TestCase
 
     public function testWithFragmentValidObject()
     {
-        $mock = new TestObject('other-fragment');
+        $mock = new StringableTestObject('other-fragment');
 
         $uri = $this->uriFactory()->withFragment($mock);
         $this->assertEquals('other-fragment', $uri->getFragment());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,7 +32,7 @@ Override::apply($classLoader, [
         }
     ],
     Message::class => [
-        'header' => function (string $string, bool $replace = true, int $statusCode = null): void {
+        'header' => function (string $string, bool $replace = true, ?int $statusCode = null): void {
             HeaderStack::push(
                 [
                     'header'      => $string,


### PR DESCRIPTION
- Backports PHP 8.4 fixes + adds one new
- Backports some phpunit fixes and adds phpunit 10 support for PHP 8

See last test run: https://github.com/williamdes/Slim-Psr7/actions/runs/13876256748

New integration tests to be fixed: https://github.com/slimphp/Slim-Psr7/issues/324#issuecomment-2726980308
Probably not related to this PR, but will have to be done for CI to pass

Fixes: #324 