### PR TITLE
Update composer dependencies and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         experimental: [false]
         composer-options: ['']
         include:
-          - php: 8.2
+          - php: 8.4
             analysis: true
           - php: nightly
             experimental: true

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
     "fig/http-message-util": "^1.1.5",
     "psr/http-factory": "^1.1",
     "psr/http-message": "^1.0 || ^2.0",
-    "ralouphie/getallheaders": "^3.0",
-    "symfony/polyfill-php80": "^1.32"
+    "ralouphie/getallheaders": "^3.0"
   },
   "require-dev": {
     "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   },
   "require-dev": {
     "ext-json": "*",
-    "adriansuter/php-autoload-override": "^1.4",
+    "adriansuter/php-autoload-override": "^1.5|| ^2.0",
     "http-interop/http-factory-tests": "^1.0 || ^2.0",
     "php-http/psr7-integration-tests": "^1.4",
     "phpspec/prophecy": "^1.22",


### PR DESCRIPTION
A few updates to composer.json to tidy it up and also move the analysis steps in the CI to PHP 8.4

- Update adriansuter/php-autoload-override constraints
- Remove symfony/ppolyfill-php80
- Run analysis on PHP 8.4 in CI
