### PR TITLE
Correct cookie expiration date format

### DIFF
--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -148,7 +148,7 @@ class Cookies
                 $timestamp = (int) $properties['expires'];
             }
             if ($timestamp && $timestamp !== 0) {
-                $result .= '; expires=' . gmdate('D, d M Y H:i:s e', $timestamp);
+                $result .= '; expires=' . gmdate('D, d M Y H:i:s', $timestamp) . ' GMT';
             }
         }
 

--- a/src/Cookies.php
+++ b/src/Cookies.php
@@ -148,7 +148,7 @@ class Cookies
                 $timestamp = (int) $properties['expires'];
             }
             if ($timestamp && $timestamp !== 0) {
-                $result .= '; expires=' . gmdate('D, d-M-Y H:i:s e', $timestamp);
+                $result .= '; expires=' . gmdate('D, d M Y H:i:s e', $timestamp);
             }
         }
 

--- a/tests/CookiesTest.php
+++ b/tests/CookiesTest.php
@@ -242,7 +242,7 @@ class CookiesTest extends TestCase
             ]
         ];
         $time = time();
-        $formattedDate = gmdate('D, d-M-Y H:i:s e', $time);
+        $formattedDate = gmdate('D, d M Y H:i:s \G\M\T', $time);
         $propertiesComplex = [
             'name' => 'test_complex',
             'properties' => [
@@ -257,7 +257,7 @@ class CookiesTest extends TestCase
             ]
         ];
         $stringDate = '2016-01-01 12:00:00';
-        $formattedStringDate = gmdate('D, d-M-Y H:i:s e', strtotime($stringDate));
+        $formattedStringDate = gmdate('D, d M Y H:i:s \G\M\T', strtotime($stringDate));
         $propertiesStringDate = [
             'name' => 'test_date',
             'properties' => [


### PR DESCRIPTION
Cloudflare recently implemented cookie expiration date format validation and is removing expiration dates from cookies when they pass through if not in the correct format.

This corrects the date format to match the spec.