### PR TITLE
Add missing PHPUnit PHP annotations

### DIFF
--- a/tests/HeadersTest.php
+++ b/tests/HeadersTest.php
@@ -12,6 +12,8 @@ namespace Slim\Tests\Psr7;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Slim\Psr7\Headers;
 use stdClass;
 
@@ -80,6 +82,7 @@ class HeadersTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testRemoveHeaderByIncompatibleStringWithRFC()
     {
         $headers = new Headers();
@@ -213,6 +216,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider provideInvalidHeaderNames
      */
+    #[DataProvider('provideInvalidHeaderNames')]
     public function testWithInvalidHeaderName($headerName): void
     {
         $headers = new Headers();
@@ -242,6 +246,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider provideInvalidHeaderValues
      */
+    #[DataProvider('provideInvalidHeaderValues')]
     public function testSetInvalidHeaderValue($headerValue)
     {
         $headers = new Headers();

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -13,6 +13,7 @@ namespace Slim\Tests\Psr7;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Stream;
 use Slim\Tests\Psr7\Mocks\MessageStub;
@@ -144,6 +145,7 @@ class MessageTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testWithoutHeaderByIncompatibleStringWithRFC()
     {
         $headers = new Headers();

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -12,6 +12,8 @@ namespace Slim\Tests\Psr7;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -98,6 +100,7 @@ class UploadedFileTest extends TestCase
      *
      * @dataProvider providerCreateFromGlobals
      */
+    #[DataProvider('providerCreateFromGlobals')]
     public function testCreateFromGlobalsFromFilesSuperglobal(array $input, array $expected)
     {
         $_FILES = $input;
@@ -111,7 +114,8 @@ class UploadedFileTest extends TestCase
      *
      * @dataProvider providerCreateFromGlobals
      */
-    public function testCreateFromGlobalsFromUserData(array $input)
+    #[DataProvider('providerCreateFromGlobals')]
+    public function testCreateFromGlobalsFromUserData(array $input, array $unused)
     {
         //If slim.files provided - it will return what was provided
         $userData['slim.files'] = $input;
@@ -191,6 +195,7 @@ class UploadedFileTest extends TestCase
      *
      * @return UploadedFile
      */
+    #[Depends('testConstructor')]
     public function testGetStream(UploadedFile $uploadedFile): UploadedFile
     {
         $stream = $uploadedFile->getStream();
@@ -206,6 +211,7 @@ class UploadedFileTest extends TestCase
      * @param UploadedFile $uploadedFile
      *
      */
+    #[Depends('testConstructor')]
     public function testMoveToNotWritable(UploadedFile $uploadedFile)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -222,6 +228,7 @@ class UploadedFileTest extends TestCase
      *
      * @return UploadedFile
      */
+    #[Depends('testConstructor')]
     public function testMoveTo(UploadedFile $uploadedFile): UploadedFile
     {
         $tempName = uniqid('file-');
@@ -255,6 +262,7 @@ class UploadedFileTest extends TestCase
      * @param UploadedFile $uploadedFile
      *
      */
+    #[Depends('testConstructorSapi')]
     public function testMoveToSapiNonUploadedFile(UploadedFile $uploadedFile)
     {
         $this->expectException(RuntimeException::class);
@@ -270,6 +278,7 @@ class UploadedFileTest extends TestCase
      * @param UploadedFile $uploadedFile
      *
      */
+    #[Depends('testConstructorSapi')]
     public function testMoveToSapiMoveUploadedFileFails(UploadedFile $uploadedFile)
     {
         $this->expectException(RuntimeException::class);
@@ -288,6 +297,7 @@ class UploadedFileTest extends TestCase
      * @param UploadedFile $uploadedFile
      *
      */
+    #[Depends('testMoveTo')]
     public function testMoveToCannotBeDoneTwice(UploadedFile $uploadedFile)
     {
         $this->expectException(RuntimeException::class);
@@ -309,6 +319,7 @@ class UploadedFileTest extends TestCase
      * @param UploadedFile $uploadedFile
      *
      */
+    #[Depends('testConstructor')]
     public function testMoveToAgain(UploadedFile $uploadedFile)
     {
         $this->expectException(RuntimeException::class);
@@ -326,6 +337,7 @@ class UploadedFileTest extends TestCase
      * @param UploadedFile $uploadedFile
      *
      */
+    #[Depends('testConstructor')]
     public function testMovedStream(UploadedFile $uploadedFile)
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
Ref: https://github.com/slimphp/Slim-Psr7/pull/311

This has no backwards compatibility impacts, I applied it in Debian.

For now we can not have phpunit 11 or 12 listed in composer json, but that does not mean that it does not work when you run phpunit 12.

Ref: https://github.com/php-http/psr7-integration-tests/issues/59